### PR TITLE
Add (failing) test for ? <p> ? query that uses broken skip function

### DIFF
--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -391,7 +391,34 @@ describe('hdt', function () {
           hasExactCount.should.equal(true);
         });
       });
+      describe('with pattern null ex:p2 null, offset 2, limit 2', function () {
+        var triples, totalCount, hasExactCount;
+        before(function (done) {
+          document.searchTriples(null, 'http://example.org/p2', null, { offset: 2, limit: 2 },
+            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        });
 
+        it('should return an array with matches', function () {
+          triples.should.be.an.Array;
+          triples.should.have.length(2);
+          triples[0].should.eql({
+            subject:   'http://example.org/s3',
+            predicate: 'http://example.org/p2',
+            object:    'http://example.org/o003' });
+          triples[1].should.eql({
+            subject:   'http://example.org/s3',
+            predicate: 'http://example.org/p2',
+            object:    'http://example.org/o004' });
+        });
+
+        it('should estimate the total count as 10', function () {
+          totalCount.should.equal(10);
+        });
+
+        it('should be an exact count', function () {
+          hasExactCount.should.equal(true);
+        });
+      });
       describe('with pattern null ex:p2 null', function () {
         var triples, totalCount, hasExactCount;
         before(function (done) {


### PR DESCRIPTION
Add (failing) test for `? <p> ?` query that uses broken skip function of middle-wavelet-iterator. 

This issue was introduced by the latest stable release, where the `canGoTo` function function of this iterator was toggled from `false` to `true`.

It's fixed (thanks @fernandes !) in the develop branch of hdt-cpp (see https://github.com/rdfhdt/hdt-cpp/commit/936e9f780060250752b161f68484b647eb89448f). It's not merged to master yet. (https://github.com/rdfhdt/hdt-cpp/issues/116 has to be resolved first I guess, let's talk about this)