### PR TITLE
add --fix flag to lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "test": "rm test/*.hdt.index 2> /dev/null; mocha",
-    "lint": "eslint lib/*.js test/*.js bin/*"
+    "lint": "eslint --fix lib/*.js test/*.js bin/*"
   },
   "dependencies": {
     "minimist": "^1.1.0",


### PR DESCRIPTION
Did some quick tests, and the `--fix` flag seems to work fine for most issues (without breakage)