### PR TITLE
Use promises instead of callbacks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,12 @@
   env: {
     node: true,
   },
-
+  parserOptions: {
+    ecmaVersion: 6
+  },
+  globals: {
+    Promise: true
+  },
   rules: {
     // Possible Errors
     comma-dangle: [2, "always-multiline"],

--- a/README.md
+++ b/README.md
@@ -18,70 +18,73 @@ $ npm install hdt
 Then require the library.
 
 ```JavaScript
-var hdt = require('hdt');
+const hdt = require('hdt');
 ```
 
 ### Opening and closing an HDT document
 Open an HDT document with `hdt.fromFile`,
-which takes filename and callback arguments.
-The HDT document will be passed to the callback.
+which takes a filename as argument and returns the HDT document in a promise.
 Close the document with `close`.
 
 ```JavaScript
-hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
+hdt.fromFile('./test/test.hdt').then(function(hdtDocument) {
   // Don't forget to close the document when you're done
-  hdtDocument.close();
+  return hdtDocument.close();
 });
 ```
 
 ### Searching for triples matching a pattern
 Search for triples with `search`,
-which takes subject, predicate, object, options, and callback arguments.
+which takes subject, predicate, object, and options arguments.
 Subject, predicate, and object can be IRIs or literals,
 [represented as simple strings](https://github.com/RubenVerborgh/N3.js#triple-representation).
 If any of these parameters is `null` or a variable, it is considered a wildcard.
 Optionally, an offset and limit can be passed in an options object,
 selecting only the specified subset.
 
-The callback returns an array of triples that match the pattern.
-A third parameter indicates an estimate of the total number of matching triples.
+The promise returns an object with an array of triples, the total number of expected triples for the pattern,
+and whether the total count is an estimate or exact.
 
 ```JavaScript
-hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
-  hdtDocument.searchTriples('http://example.org/s1', null, null, { offset: 0, limit: 10 },
-    function (error, triples, totalCount) {
-      console.log('Approximately ' + totalCount + ' triples match the pattern.');
-      triples.forEach(function (triple) { console.log(triple); });
-      hdtDocument.close();
-    });
-});
+var doc;
+hdt.fromFile('./test/test.hdt')
+  .then(function(hdtDocument) {
+    doc = hdtDocument;
+    return doc.searchTriples('http://example.org/s1', null, null, { offset: 0, limit: 10 })
+  })
+  .then(function(result) {
+    console.log('Approximately ' + result.totalCount + ' triples match the pattern.');
+    result.triples.forEach(function (triple) { console.log(triple); });
+    return doc.close();
+  });
 ```
 
 ### Counting triples matching a pattern
 Retrieve an estimate of the total number of triples matching a pattern with `count`,
-which takes subject, predicate, object, and callback arguments.
+which takes subject, predicate, and object arguments.
 
 ```JavaScript
-hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
-  hdtDocument.countTriples('http://example.org/s1', null, null,
-    function (error, totalCount) {
-      console.log('Approximately ' + totalCount + ' triples match the pattern.');
-      hdtDocument.close();
-    });
-});
+var doc;
+hdt.fromFile('./test/test.hdt')
+  .then(function(hdtDocument) {
+    doc = hdtDocument;
+    return doc.countTriples('http://example.org/s1', null, null);
+  })
+  .then(function(result) {
+    console.log('Approximately ' + result.totalCount + ' triples match the pattern.');
+    return doc.close()
+  });
 ```
 
 ### Search terms starting with a prefix
 Find terms (literals and IRIs) that start with a given prefix.
 
 ```JavaScript
-hdtDocument.searchTerms({ prefix: 'http://example.org/', limit: 100, position: 'object' },
-    function (error, suggestions) {
-      if (error) console.error('Error!', error)
-      console.log('Found ' + suggestions.length + ' suggestions');
-      hdtDocument.close();
-    });
-});
+hdtDocument.searchTerms({ prefix: 'http://example.org/', limit: 100, position: 'object' })
+  .then(function(suggestions) {
+    console.log('Found ' + suggestions.length + ' suggestions');
+    return hdtDocument.close();
+  });
 ```
 
 ### Searching literals containing a substring
@@ -89,14 +92,17 @@ In an HDT file that was [generated with an FM index](https://github.com/LinkedDa
 you can search for literals that contain a certain substring.
 
 ```JavaScript
-hdt.fromFile('./test/literals.hdt', function (error, hdtDocument) {
-  hdtDocument.searchLiterals('b', { offset: 0, limit: 5 },
-    function (error, literals, totalCount) {
-      console.log('Approximately ' + totalCount + ' literals contain the pattern.');
-      literals.forEach(function (literal) { console.log(literal); });
-      hdtDocument.close();
-    });
-});
+var doc;
+hdt.fromFile('./test/test.hdt')
+  .then(function(hdtDocument) {
+    doc = hdtDocument;
+    return doc.searchLiterals('b', { offset: 0, limit: 5 });
+  })
+  .then(function(result) {
+    console.log('Approximately ' + result.totalCount + ' literals contain the pattern.');
+    result.literals.forEach(function (literal) { console.log(literal); });
+    return doc.close();
+  });
 ```
 
 ## Standalone utility

--- a/bin/hdt
+++ b/bin/hdt
@@ -26,18 +26,16 @@ var parts = /^\s*<?([^\s>]*)>?\s*<?([^\s>]*)>?\s*<?([^]*?)>?\s*$/.exec(query),
 var writer = new N3.Writer(process.stdout, { format: format, end: false });
 
 // Load the HDT file
-hdt.fromFile(hdtFile, function (error, hdtDocument) {
-  if (error) console.error(error.message), process.exit(1);
-  // Search the HDT document for the given pattern
-  hdtDocument.search(subject, predicate, object, { offset: offset, limit: limit },
-    function (error, triples, totalCount, exactCount) {
-      // Write all matching triples
-      if (error) console.error('Error:', error.message), process.exit(1);
-      process.stdout.write('# Total matches: ' + totalCount +
-                           (exactCount ? '' : ' (estimated)') + '\n');
-      writer.addTriples(triples);
+hdt.fromFile(hdtFile)
+  .then(hdtDocument => hdtDocument.search(subject, predicate, object, { offset: offset, limit: limit }))
+  .then(
+    results => {
+      process.stdout.write('# Total matches: ' + results.totalCount +
+                           (results.exactCount ? '' : ' (estimated)') + '\n');
+      writer.addTriples(results.triples);
       writer.end();
-      hdtDocument.close();
-    });
-});
-
+    },
+  (error) => {
+    console.error(error.message), process.exit(1);
+  }
+);

--- a/bin/hdt
+++ b/bin/hdt
@@ -35,7 +35,7 @@ hdt.fromFile(hdtFile)
       writer.addTriples(results.triples);
       writer.end();
     },
-  (error) => {
-    console.error(error.message), process.exit(1);
-  }
-);
+    error => {
+      console.error(error.message), process.exit(1);
+    }
+  );

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -54,7 +54,7 @@ const Nan::Persistent<Function>& HdtDocument::GetConstructor() {
     Nan::SetPrototypeMethod(constructorTemplate, "_searchTriples",  SearchTriples);
     Nan::SetPrototypeMethod(constructorTemplate, "_searchLiterals", SearchLiterals);
     Nan::SetPrototypeMethod(constructorTemplate, "_searchTerms",    SearchTerms);
-    Nan::SetPrototypeMethod(constructorTemplate, "close",           Close);
+    Nan::SetPrototypeMethod(constructorTemplate, "_close",           Close);
     Nan::SetAccessor(constructorTemplate->PrototypeTemplate(),
                      Nan::New("_features").ToLocalChecked(), Features);
     Nan::SetAccessor(constructorTemplate->PrototypeTemplate(),

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -54,7 +54,7 @@ const Nan::Persistent<Function>& HdtDocument::GetConstructor() {
     Nan::SetPrototypeMethod(constructorTemplate, "_searchTriples",  SearchTriples);
     Nan::SetPrototypeMethod(constructorTemplate, "_searchLiterals", SearchLiterals);
     Nan::SetPrototypeMethod(constructorTemplate, "_searchTerms",    SearchTerms);
-    Nan::SetPrototypeMethod(constructorTemplate, "_close",           Close);
+    Nan::SetPrototypeMethod(constructorTemplate, "_close",          Close);
     Nan::SetAccessor(constructorTemplate->PrototypeTemplate(),
                      Nan::New("_features").ToLocalChecked(), Features);
     Nan::SetAccessor(constructorTemplate->PrototypeTemplate(),

--- a/lib/hdt.d.ts
+++ b/lib/hdt.d.ts
@@ -1,0 +1,44 @@
+declare module "hdt" {
+  export interface Statement {
+    subject: string;
+    predicate: string;
+    object: string;
+  }
+
+  export interface SearchTermsOpts {
+    limit?: number;
+    position?: "subject" | "predicate" | "object";
+    prefix?: string;
+  }
+
+  export interface SearchLiteralsOpts {
+    limit?: number;
+    offset?: number;
+  }
+
+  export interface SearchLiteralsResult {
+    literals: string[];
+    totalCount: number;
+  }
+
+  export interface SearchTriplesOpts {
+    limit?: number;
+    offset?: number;
+  }
+
+  export interface SearchResult {
+    triples: Statement[];
+    totalCount: number;
+    hasExactCount: boolean;
+  }
+
+  export interface Document {
+    searchTriples(sub?: string, pred?: string, obj?: string, opts?: SearchTriplesOpts): Promise<SearchResult>;
+    countTriples(sub?: string, pred?: string, obj?: string): Promise<SearchResult>;
+    searchLiterals(substring: string, opts?: SearchLiteralsOpts): Promise<SearchLiteralsResult>;
+    searchTerms(opts?: SearchTermsOpts): Promise<string[]>;
+    close(): Promise<void>;
+  }
+  
+  export function fromFile(filename: string): Promise<Document>;
+}

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -15,21 +15,17 @@ HdtDocumentPrototype.searchTriples = function (subject, predicate, object, optio
 
   return new Promise((resolve, reject) => {
     this._searchTriples(subject, predicate, object, offset, limit, function (err, triples, totalCount, hasExactCount) {
-      if (err) return reject(err);
-
-      return resolve({
-        triples,
-        totalCount,
-        hasExactCount,
-      });
+      if (err)
+        reject(err);
+      else
+        resolve({ triples, totalCount, hasExactCount });
     }, this);
   });
 };
 
 // Gives an approximate number of matches of triples with the given subject, predicate, and object.
 HdtDocumentPrototype.countTriples = function (subject, predicate, object) {
-  return this.search(subject, predicate, object, { offset: 0, limit: 0 })
-    .then(results => ({ totalCount: results.totalCount, hasExactCount: results.hasExactCount }));
+  return this.search(subject, predicate, object, { offset: 0, limit: 0 });
 };
 
 // Searches the document for literals that contain the given string
@@ -40,11 +36,10 @@ HdtDocumentPrototype.searchLiterals = function (substring, options) {
 
   return new Promise((resolve, reject) => {
     this._searchLiterals(substring, offset, limit, function (err, literals, totalCount) {
-      if (err) return reject(err);
-      resolve({
-        literals,
-        totalCount,
-      });
+      if (err)
+        return reject(err);
+      else
+        resolve({ literals, totalCount  });
     }, this);
   });
 };
@@ -57,24 +52,28 @@ const POSITIONS = {
 };
 HdtDocumentPrototype.searchTerms = function (options) {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
-  const limit = options && options.limit ? Math.max(0, parseInt(options.limit, 10)) : 100;
-  const position = options && options.position;
-  const prefix = options && options.prefix || '';
-  const posId = POSITIONS[position];
+  const limit = options && options.limit ? Math.max(0, parseInt(options.limit, 10)) : 100,
+      position = options && options.position,
+      prefix = options && options.prefix || '',
+      posId = POSITIONS[position];
   if (!(position in POSITIONS))
     return Promise.reject(new Error('Invalid position argument. Expected subject, predicate or object.'));
   return new Promise((resolve, reject) => {
     this._searchTerms(prefix, limit, posId, (error, results) => {
-      if (error) return reject(error);
-      resolve(results);
+      if (error)
+        reject(error);
+      else
+        resolve(results);
     }, this);
   });
 };
 HdtDocumentPrototype.close = function () {
   return new Promise((resolve, reject) => {
-    this._close(function (e) {
-      if (e) return reject(e);
-      resolve();
+    this._close(function (err) {
+      if (err)
+        reject(err);
+      else
+        resolve();
     });
   });
 };
@@ -103,7 +102,7 @@ module.exports = {
           case 'Non-HDT Section':
             return reject(new Error('The file "' + filename + '" is not a valid HDT file'));
           default:
-            reject(error);
+            return reject(error);
           }
         }
         // Document the features of the HDT file

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -5,53 +5,78 @@ var hdtNative = require('../build/Release/hdt');
 var HdtDocumentPrototype = hdtNative.HdtDocument.prototype;
 
 // Searches the document for triples with the given subject, predicate, and object.
-HdtDocumentPrototype.searchTriples = function (subject, predicate, object, options, callback, self) {
-  if (typeof  callback !== 'function') self = callback, callback = options, options = {};
-  if (typeof  callback !== 'function') return;
-  if (this.closed) return callback.call(self || this, new Error('The HDT document cannot be read because it is closed'));
+HdtDocumentPrototype.searchTriples = function (subject, predicate, object, options) {
+  if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
   if (typeof   subject !== 'string' ||   subject[0] === '?') subject   = '';
   if (typeof predicate !== 'string' || predicate[0] === '?') predicate = '';
   if (typeof    object !== 'string' ||    object[0] === '?') object    = '';
-  var offset = options && options.offset ? Math.max(0, parseInt(options.offset, 10)) : 0,
+  const offset = options && options.offset ? Math.max(0, parseInt(options.offset, 10)) : 0,
       limit  = options && options.limit  ? Math.max(0, parseInt(options.limit,  10)) : 0;
 
-  this._searchTriples(subject, predicate, object, offset, limit, callback, self);
+  return new Promise((resolve, reject) => {
+    this._searchTriples(subject, predicate, object, offset, limit, function (err, triples, totalCount, hasExactCount) {
+      if (err) return reject(err);
+
+      return resolve({
+        triples,
+        totalCount,
+        hasExactCount,
+      });
+    }, this);
+  });
 };
 
 // Gives an approximate number of matches of triples with the given subject, predicate, and object.
-HdtDocumentPrototype.countTriples = function (subject, predicate, object, callback, self) {
-  this.search(subject, predicate, object, { offset: 0, limit: 0 },
-              function (error, triples, totalCount, hasExactCount) {
-                callback.call(this, error, totalCount, hasExactCount);
-              }, self);
+HdtDocumentPrototype.countTriples = function (subject, predicate, object) {
+  return this.search(subject, predicate, object, { offset: 0, limit: 0 })
+    .then(results => ({ totalCount: results.totalCount, hasExactCount: results.hasExactCount }));
 };
 
 // Searches the document for literals that contain the given string
-HdtDocumentPrototype.searchLiterals = function (substring, options, callback, self) {
-  if (typeof  callback !== 'function') self = callback, callback = options, options = {};
-  if (typeof  callback !== 'function') return;
-  if (this.closed) return callback.call(self || this, new Error('The HDT document cannot be read because it is closed'));
-  var offset = options && options.offset ? Math.max(0, parseInt(options.offset, 10)) : 0,
+HdtDocumentPrototype.searchLiterals = function (substring, options) {
+  if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
+  const offset = options && options.offset ? Math.max(0, parseInt(options.offset, 10)) : 0,
       limit  = options && options.limit  ? Math.max(0, parseInt(options.limit,  10)) : 0;
-  this._searchLiterals(substring, offset, limit, callback, self);
+
+  return new Promise((resolve, reject) => {
+    this._searchLiterals(substring, offset, limit, function (err, literals, totalCount) {
+      if (err) return reject(err);
+      resolve({
+        literals,
+        totalCount,
+      });
+    }, this);
+  });
 };
 
 // Searches the document for literals that contain the given string
-var POSITIONS = {
+const POSITIONS = {
   subject: 0,
   predicate: 1,
   object: 2,
 };
-HdtDocumentPrototype.searchTerms = function (options, callback, self) {
-  if (typeof  callback !== 'function') return;
-  if (this.closed) return callback.call(self || this, new Error('The HDT document cannot be read because it is closed'));
-  var limit = options && options.limit ? Math.max(0, parseInt(options.limit, 10)) : 100;
-  var position = options && options.position;
-  var prefix = options && options.prefix || '';
-  var posId = POSITIONS[position];
+HdtDocumentPrototype.searchTerms = function (options) {
+  if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
+  const limit = options && options.limit ? Math.max(0, parseInt(options.limit, 10)) : 100;
+  const position = options && options.position;
+  const prefix = options && options.prefix || '';
+  const posId = POSITIONS[position];
   if (!(position in POSITIONS))
-    return callback.call(self || this, new Error('Invalid position argument. Expected subject, predicate or object.'));
-  this._searchTerms(prefix, limit, posId, callback, self);
+    return Promise.reject(new Error('Invalid position argument. Expected subject, predicate or object.'));
+  return new Promise((resolve, reject) => {
+    this._searchTerms(prefix, limit, posId, (error, results) => {
+      if (error) return reject(error);
+      resolve(results);
+    }, this);
+  });
+};
+HdtDocumentPrototype.close = function () {
+  return new Promise((resolve, reject) => {
+    this._close(function (e) {
+      if (e) return reject(e);
+      resolve();
+    });
+  });
 };
 
 // Deprecated method names
@@ -64,31 +89,31 @@ HdtDocumentPrototype.search = HdtDocumentPrototype.searchTriples;
 
 module.exports = {
   // Creates an HDT document for the given file.
-  fromFile: function (filename, callback, self) {
-    if (typeof callback !== 'function') return;
+  fromFile: function (filename) {
     if (typeof filename !== 'string' || filename.length === 0)
-      return callback.call(self, Error('Invalid filename: ' + filename));
+      return Promise.reject(Error('Invalid filename: ' + filename));
 
-    // Construct the native HdtDocument
-    hdtNative.createHdtDocument(filename, function (error, document) {
-      // Abort the creation if any error occurred
-      if (error) {
-        switch (error.message) {
-        case 'Error opening HDT file for mapping.':
-          return callback.call(self, Error('Could not open HDT file "' + filename + '"'));
-        case 'Non-HDT Section':
-          return callback.call(self, Error('The file "' + filename + '" is not a valid HDT file'));
-        default:
-          return callback.call(self, error);
+    return new Promise((resolve, reject) => {
+      hdtNative.createHdtDocument(filename, function (error, document) {
+        // Abort the creation if any error occurred
+        if (error) {
+          switch (error.message) {
+          case 'Error opening HDT file for mapping.':
+            return reject(new Error('Could not open HDT file "' + filename + '"'));
+          case 'Non-HDT Section':
+            return reject(new Error('The file "' + filename + '" is not a valid HDT file'));
+          default:
+            reject(error);
+          }
         }
-      }
-      // Document the features of the HDT file
-      document.features = Object.freeze({
-        searchTriples:  true, // supported by default
-        countTriples:   true, // supported by default
-        searchLiterals: !!(document._features & 1),
+        // Document the features of the HDT file
+        document.features = Object.freeze({
+          searchTriples:  true, // supported by default
+          countTriples:   true, // supported by default
+          searchLiterals: !!(document._features & 1),
+        });
+        resolve(document);
       });
-      callback.call(self, null, document);
     });
   },
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "LGPL-3.0",
   "main": "./lib/hdt",
   "bin": "./bin/hdt",
+  "types": "./lib/hdt.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/RubenVerborgh/HDT-Node.git"

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -11,72 +11,42 @@ describe('hdt', function () {
 
   describe('creating a new HDT document with fromFile', function () {
     describe('with a non-string argument', function () {
-      it('should throw an error', function (done) {
-        var self = {};
-        hdt.fromFile(null, function (error) {
-          this.should.equal(self);
+      it('should throw an error', function () {
+        return hdt.fromFile(null).then(() => Promise.reject(new Error('Expected an error')), (error) => {
           error.should.be.an.Error;
           error.message.should.equal('Invalid filename: null');
-          done();
-        }, self);
-      });
-    });
-
-    describe('with a non-existing file as argument', function () {
-      it('should throw an error', function (done) {
-        var self = {};
-        hdt.fromFile('abc', function (error) {
-          this.should.equal(self);
-          error.should.be.an.Error;
-          error.message.should.equal('Could not open HDT file "abc"');
-          done();
-        }, self);
-      });
-    });
-
-    describe('with a non-HDT file as argument', function () {
-      it('should throw an error', function (done) {
-        var self = {};
-        hdt.fromFile('./test/hdt-test.js', function (error) {
-          this.should.equal(self);
-          error.should.be.an.Error;
-          error.message.should.equal('The file "./test/hdt-test.js" is not a valid HDT file');
-          done();
-        }, self);
-      });
-    });
-
-    describe('without self value', function () {
-      it('should invoke the callback', function (done) {
-        hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
-          hdtDocument.close();
-          done(error);
         });
       });
     });
 
-    describe('with a self value', function () {
-      it('should invoke the callback with that value as `this`', function (done) {
-        var self = {};
-        hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
-          this.should.equal(self);
-          hdtDocument.close();
-          done(error);
-        }, self);
+    describe('with a non-existing file as argument', function () {
+      it('should throw an error', function () {
+        return hdt.fromFile('abc').then(() => Promise.reject(new Error('Expected an error')), (error) => {
+          error.should.be.an.Error;
+          error.message.should.equal('Could not open HDT file "abc"');
+        });
+      });
+    });
+
+    describe('with a non-HDT file as argument', function () {
+      it('should throw an error', function () {
+        return hdt.fromFile('./test/hdt-test.js').then(() => Promise.reject(new Error('Expected an error')), (error) => {
+          error.should.be.an.Error;
+          error.message.should.equal('The file "./test/hdt-test.js" is not a valid HDT file');
+        });
       });
     });
   });
 
   describe('An HDT document for an example HDT file', function () {
     var document;
-    before(function (done) {
-      hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
+    before(function () {
+      return hdt.fromFile('./test/test.hdt').then(hdtDocument => {
         document = hdtDocument;
-        done(error);
       });
     });
-    after(function (done) {
-      document.close(done);
+    after(function () {
+      return document.close();
     });
 
     describe('asked for supported features', function () {
@@ -98,99 +68,61 @@ describe('hdt', function () {
     });
 
     describe('getting suggestions', function () {
-      it('Should have correct results for predicate position', function (done) {
-        document.searchTerms({ prefix: 'http://example.org/', limit:100, position : 'predicate' },
-          function (error, suggestions) {
-            if (error) return done(error);
-            suggestions.should.have.lengthOf(3);
-            suggestions[0].should.equal('http://example.org/p1');
-            done();
-          });
+      it('Should have correct results for predicate position', function () {
+        return document.searchTerms({ prefix: 'http://example.org/', limit:100, position : 'predicate' }).then(suggestions => {
+          suggestions.should.have.lengthOf(3);
+          suggestions[0].should.equal('http://example.org/p1');
+        });
       });
-      it('Should have correct results for object position', function (done) {
-        document.searchTerms({ prefix: 'http://example.org/', limit: 2, position : 'object' },
-          function (error, suggestions) {
-            if (error) return done(error);
-            suggestions[0].should.equal('http://example.org/o001');
-            suggestions.should.have.lengthOf(2);
-            done();
-          });
+      it('Should have correct results for object position', function () {
+        return document.searchTerms({ prefix: 'http://example.org/', limit: 2, position : 'object' }).then(suggestions => {
+          suggestions[0].should.equal('http://example.org/o001');
+          suggestions.should.have.lengthOf(2);
+        });
       });
-      it('Should get suggestions for literals', function (done) {
-        document.searchTerms({ prefix: '"a', position : 'object' },
-          function (error, suggestions) {
-            if (error) return done(error);
-            suggestions.should.have.lengthOf(8);
-            done();
-          });
+      it('Should get suggestions for literals', function () {
+        return document.searchTerms({ prefix: '"a', position : 'object' }).then(suggestions => {
+          suggestions.should.have.lengthOf(8);
+        });
       });
-      it('Should 100 results on empty match', function (done) {
-        document.searchTerms({ prefix: '', position: 'object' },
-          function (error, suggestions) {
-            if (error) return done(error);
-            suggestions.should.have.lengthOf(100);
-            done();
-          });
+      it('Should 100 results on empty match', function () {
+        return document.searchTerms({ prefix: '', position: 'object' }).then(suggestions => {
+          suggestions.should.have.lengthOf(100);
+        });
       });
-      it('Should 100 results when prefix is not defined', function (done) {
-        document.searchTerms({ position: 'object' },
-          function (error, suggestions) {
-            if (error) return done(error);
-            suggestions.should.have.lengthOf(100);
-            done();
-          });
+      it('Should 100 results when prefix is not defined', function () {
+        return document.searchTerms({ position: 'object' }).then(suggestions => {
+          suggestions.should.have.lengthOf(100);
+        });
       });
-      it('Should return 0 results on negative limit', function (done) {
-        document.searchTerms({ prefix: 'http://example.org/', limit: -1, position: 'object' },
-          function (error, suggestions) {
-            if (error) return done(error);
-            suggestions.should.have.lengthOf(0);
-            done();
-          });
+      it('Should return 0 results on negative limit', function () {
+        return document.searchTerms({ prefix: 'http://example.org/', limit: -1, position: 'object' }).then(suggestions => {
+          suggestions.should.have.lengthOf(0);
+        });
       });
-      it('Should return 0 results invalid limit val', function (done) {
-        document.searchTerms({ prefix: 'http://example.org/', limit: 'sdf', position: 'object' },
-          function (error, suggestions) {
-            if (error) return done(error);
-            suggestions.should.have.lengthOf(0);
-            done();
-          });
+      it('Should return 0 results invalid limit val', function () {
+        return document.searchTerms({ prefix: 'http://example.org/', limit: 'sdf', position: 'object' }).then(suggestions => {
+          suggestions.should.have.lengthOf(0);
+        });
       });
-      it('Should throw on invalid position', function (done) {
-        document.searchTerms({ prefix: 'http://example.org/', limit: 'sdf', position: 'bla' },
-          function (error, suggestions) {
+      it('Should throw on invalid position', function () {
+        return document.searchTerms({ prefix: 'http://example.org/', limit: 'sdf', position: 'bla' }).then(
+          () => Promise.reject(new Error('Expected an error')),
+          (error) => {
             error.should.be.an.instanceOf(Error);
             error.message.should.equal('Invalid position argument. Expected subject, predicate or object.');
-            if (error) return done();
-            done(new Error('expected an error'));
-          });
+          }
+        );
       });
     });
     describe('being searched', function () {
-      describe('without self value', function () {
-        it('should invoke the callback with the HDT document as `this`', function (done) {
-          document.searchTriples('a', 'b', 'c', function (error) {
-            this.should.equal(document);
-            done(error);
-          });
-        });
-      });
-
-      describe('with a self value', function () {
-        var self = {};
-        it('should invoke the callback with that value as `this`', function (done) {
-          document.searchTriples('a', 'b', 'c', function (error) {
-            this.should.equal(self);
-            done(error);
-          }, self);
-        });
-      });
-
       describe('with a non-existing pattern', function () {
         var triples, totalCount;
-        before(function (done) {
-          document.searchTriples('a', null, null,
-            function (error, t, c) { triples = t; totalCount = c; done(error); });
+        before(function () {
+          return document.searchTriples('a', null, null).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -205,9 +137,12 @@ describe('hdt', function () {
 
       describe('with pattern null null null', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, null, null,
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null, null, null).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -230,9 +165,12 @@ describe('hdt', function () {
 
       describe('with pattern null null null, offset 0 and limit 10', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, null, null, { offset: 0, limit: 10 },
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null, null, null, { offset: 0, limit: 10 }).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -255,9 +193,12 @@ describe('hdt', function () {
 
       describe('with pattern null null null, offset 10 and limit 5', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, null, null, { offset: 10, limit: 5 },
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null, null, null, { offset: 10, limit: 5 }).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -280,9 +221,12 @@ describe('hdt', function () {
 
       describe('with pattern null null null, offset 200 and limit 5', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, null, null, { offset: 200, limit: 5 },
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null, null, null, { offset: 200, limit: 5 }).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -301,9 +245,12 @@ describe('hdt', function () {
 
       describe('with pattern ex:s2 null null', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples('http://example.org/s2', null, null,
-                          function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples('http://example.org/s2', null, null).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -330,9 +277,10 @@ describe('hdt', function () {
 
       describe('with pattern ex:s2 ex:p1 null', function () {
         var triples;
-        before(function (done) {
-          document.searchTriples('http://example.org/s2', 'http://example.org/p1', null,
-                          function (error, t, c, e) { triples = t; done(error); });
+        before(function () {
+          return document.searchTriples('http://example.org/s2', 'http://example.org/p1', null).then(result => {
+            triples = result.triples;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -351,9 +299,10 @@ describe('hdt', function () {
 
       describe('with pattern ex:s2 ex:p1 ex:o010', function () {
         var triples;
-        before(function (done) {
-          document.searchTriples('http://example.org/s2', 'http://example.org/p1', 'http://example.org/o010',
-                          function (error, t, c, e) { triples = t; done(error); });
+        before(function () {
+          return document.searchTriples('http://example.org/s2', 'http://example.org/p1', 'http://example.org/o010').then(result => {
+            triples = result.triples;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -371,9 +320,10 @@ describe('hdt', function () {
       // Link to issue -> https://github.com/rdfhdt/hdt-cpp/issues/84
       describe('with pattern null null ex:o010', function () {
         var triples;
-        before(function (done) {
-          document.searchTriples(null, null, 'http://example.org/o010',
-                          function (error, t, c, e) { triples = t; done(error); });
+        before(function () {
+          return document.searchTriples(null, null, 'http://example.org/o010').then(result => {
+            triples = result.triples;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -388,9 +338,12 @@ describe('hdt', function () {
 
       describe('with pattern ex:s2 null null, offset 2 and limit 1', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples('http://example.org/s2', null, null, { offset: 2, limit: 1 },
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples('http://example.org/s2', null, null, { offset: 2, limit: 1 }).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -413,9 +366,12 @@ describe('hdt', function () {
 
       describe('with pattern ex:s2 null null, offset 200 and limit 1', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples('http://example.org/s2', null, null, { offset: 200, limit: 1 },
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples('http://example.org/s2', null, null, { offset: 200, limit: 1 }).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -434,9 +390,12 @@ describe('hdt', function () {
 
       describe('with pattern ex:s2 ?p ?o', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples('http://example.org/s2', '?p', '?o',
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples('http://example.org/s2', '?p', '?o').then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -463,9 +422,12 @@ describe('hdt', function () {
 
       describe('with pattern null ex:p2 null, offset 2, limit 2', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, 'http://example.org/p2', null, { offset: 2, limit: 2 },
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null, 'http://example.org/p2', null, { offset: 2, limit: 2 }).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -492,9 +454,12 @@ describe('hdt', function () {
 
       describe('with pattern null ex:p2 null', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, 'http://example.org/p2', null,
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null, 'http://example.org/p2', null).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -521,9 +486,12 @@ describe('hdt', function () {
 
       describe('with pattern null ex:p3 null', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, 'http://example.org/p3', null,
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null, 'http://example.org/p3', null).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -590,9 +558,12 @@ describe('hdt', function () {
 
       describe('with pattern null null "a"^^http://example.org/literal', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, null, '"a"^^http://example.org/literal',
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null,  null, '"a"^^http://example.org/literal').then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -615,10 +586,14 @@ describe('hdt', function () {
 
       describe('with pattern null null ex:o012', function () {
         var triples, totalCount, hasExactCount;
-        before(function (done) {
-          document.searchTriples(null, null, 'http://example.org/o012',
-            function (error, t, c, e) { triples = t; totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.searchTriples(null,  null, 'http://example.org/o012').then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
+
 
         it('should return an array with matches', function () {
           triples.should.be.an.Array;
@@ -640,30 +615,13 @@ describe('hdt', function () {
     });
 
     describe('being counted', function () {
-      describe('without self value', function () {
-        it('should invoke the callback with the HDT document as `this`', function (done) {
-          document.countTriples('a', 'b', 'c', function (error) {
-            this.should.equal(document);
-            done(error);
-          });
-        });
-      });
-
-      describe('with a self value', function () {
-        var self = {};
-        it('should invoke the callback with that value as `this`', function (done) {
-          document.countTriples('a', 'b', 'c', function (error) {
-            this.should.equal(self);
-            done(error);
-          }, self);
-        });
-      });
-
       describe('with a non-existing pattern', function () {
         var totalCount, hasExactCount;
-        before(function (done) {
-          document.countTriples('a', null, null,
-                                function (error, c, e) { totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.countTriples('a', null, null).then(result => {
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return 0', function () {
@@ -677,9 +635,11 @@ describe('hdt', function () {
 
       describe('with pattern null null null', function () {
         var totalCount, hasExactCount;
-        before(function (done) {
-          document.countTriples(null, null, null,
-                                function (error, c, e) { totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.countTriples(null, null, null).then(result => {
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return 132', function () {
@@ -693,9 +653,11 @@ describe('hdt', function () {
 
       describe('with pattern ex:s2 null null', function () {
         var totalCount, hasExactCount;
-        before(function (done) {
-          document.countTriples('http://example.org/s2', null, null,
-                                function (error, c, e) { totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.countTriples('http://example.org/s2', null, null).then(result => {
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return 10', function () {
@@ -709,9 +671,11 @@ describe('hdt', function () {
 
       describe('with pattern null ex:p2 null', function () {
         var totalCount, hasExactCount;
-        before(function (done) {
-          document.countTriples(null, 'http://example.org/p2', null,
-                                function (error, c, e) { totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.countTriples(null, 'http://example.org/p2', null).then(result => {
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return 10', function () {
@@ -725,9 +689,11 @@ describe('hdt', function () {
 
       describe('with pattern null ex:p3 null', function () {
         var totalCount, hasExactCount;
-        before(function (done) {
-          document.countTriples(null, 'http://example.org/p3', null,
-                                function (error, c, e) { totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.countTriples(null, 'http://example.org/p3', null).then(result => {
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return 12', function () {
@@ -741,9 +707,11 @@ describe('hdt', function () {
 
       describe('with pattern null null ex:o012', function () {
         var totalCount, hasExactCount;
-        before(function (done) {
-          document.countTriples(null, null, 'http://example.org/o012',
-                                function (error, c, e) { totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.countTriples(null, null, 'http://example.org/o012').then(result => {
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return 1', function () {
@@ -757,9 +725,11 @@ describe('hdt', function () {
 
       describe('with pattern null null "a"^^http://example.org/literal', function () {
         var totalCount, hasExactCount;
-        before(function (done) {
-          document.countTriples(null, null, '"a"^^http://example.org/literal',
-                                function (error, c, e) { totalCount = c; hasExactCount = e; done(error); });
+        before(function () {
+          return document.countTriples(null, null, '"a"^^http://example.org/literal').then(result => {
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
         });
 
         it('should return 1', function () {
@@ -771,61 +741,41 @@ describe('hdt', function () {
         });
       });
     });
-
-    describe('being closed', function () {
-      var self = {}, callbackThis, callbackArgs;
-      before(function (done) {
-        document.close(function (error) {
-          callbackThis = this, callbackArgs = arguments;
-          done(error);
-        }, self);
-      });
-
-      it('should not pass an error through the callback', function () {
-        callbackArgs.should.have.length(1);
-        callbackArgs.should.have.property(0, null);
-      });
-
-      it('should invoke the callback with the second argument as `this`', function () {
-        callbackThis.should.equal(self);
-      });
-    });
   });
 
   describe('An HDT document without a literal dictionary', function () {
     var document;
-    before(function (done) {
-      hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
+    before(function () {
+      return hdt.fromFile('./test/test.hdt').then(hdtDocument => {
         document = hdtDocument;
-        done(error);
       });
     });
-    after(function (done) {
-      document.close(done);
+    after(function () {
+      return document.close();
     });
 
     describe('being searched for literals', function () {
-      it('should throw an error', function (done) {
-        document.searchLiterals('abc', function (error) {
-          this.should.equal(document);
-          error.should.be.an.instanceOf(Error);
-          error.message.should.equal('The HDT document does not support literal search');
-          done();
-        });
+      it('should throw an error', function () {
+        return document.searchLiterals('abc').then(
+          () => Promise.reject(new Error('expected an error')),
+          (error) => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('The HDT document does not support literal search');
+          }
+        );
       });
     });
   });
 
   describe('An HDT document with a literal dictionary', function () {
     var document;
-    before(function (done) {
-      hdt.fromFile('./test/literals.hdt', function (error, hdtDocument) {
+    before(function () {
+      return hdt.fromFile('./test/literals.hdt').then(hdtDocument => {
         document = hdtDocument;
-        done(error);
       });
     });
-    after(function (done) {
-      document.close(done);
+    after(function () {
+      return document.close();
     });
 
     describe('asked for supported features', function () {
@@ -849,9 +799,11 @@ describe('hdt', function () {
     describe('being searched', function () {
       describe('for an existing subject', function () {
         var triples, totalCount;
-        before(function (done) {
-          document.searchTriples('s', null, null,
-            function (error, t, c) { triples = t; totalCount = c; done(error); });
+        before(function () {
+          return document.searchTriples('s', null, null).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+          });
         });
 
         it('should return an array with matches', function () {
@@ -866,9 +818,11 @@ describe('hdt', function () {
 
       describe('for a non-existing subject', function () {
         var triples, totalCount;
-        before(function (done) {
-          document.searchTriples('x', null, null,
-            function (error, t, c) { triples = t; totalCount = c; done(error); });
+        before(function () {
+          return document.searchTriples('x', null, null).then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+          });
         });
 
         it('should return an array without matches', function () {
@@ -883,9 +837,11 @@ describe('hdt', function () {
 
       describe('for the empty literal', function () {
         var literals, totalCount;
-        before(function (done) {
-          document.searchLiterals('',
-            function (error, l, c) { literals = l, totalCount = c; done(error); });
+        before(function () {
+          return document.searchLiterals('').then(result => {
+            literals = result.literals;
+            totalCount = result.totalCount;
+          });
         });
 
         it('should return the empty array', function () {
@@ -899,9 +855,11 @@ describe('hdt', function () {
 
       describe('for the literal "a"', function () {
         var literals, totalCount;
-        before(function (done) {
-          document.searchLiterals('a',
-            function (error, l, c) { literals = l, totalCount = c; done(error); });
+        before(function () {
+          return document.searchLiterals('a').then(result => {
+            literals = result.literals;
+            totalCount = result.totalCount;
+          });
         });
 
         it('should return literals containing "a"', function () {
@@ -915,10 +873,13 @@ describe('hdt', function () {
 
       describe('for the literal "b"', function () {
         var literals, totalCount;
-        before(function (done) {
-          document.searchLiterals('b',
-            function (error, l, c) { literals = l, totalCount = c; done(error); });
+        before(function () {
+          return document.searchLiterals('b').then(result => {
+            literals = result.literals;
+            totalCount = result.totalCount;
+          });
         });
+
 
         it('should return literals containing "b" (with duplicates for multiple matches)', function () {
           literals.should.eql([
@@ -934,9 +895,11 @@ describe('hdt', function () {
 
       describe('for the literal "b" with a limit', function () {
         var literals, totalCount;
-        before(function (done) {
-          document.searchLiterals('b', { limit: 2 },
-            function (error, l, c) { literals = l, totalCount = c; done(error); });
+        before(function () {
+          return document.searchLiterals('b', { limit : 2 }).then(result => {
+            literals = result.literals;
+            totalCount = result.totalCount;
+          });
         });
 
         it('should return literals containing "b"', function () {
@@ -950,10 +913,13 @@ describe('hdt', function () {
 
       describe('for the literal "b" with an offset', function () {
         var literals, totalCount;
-        before(function (done) {
-          document.searchLiterals('b', { offset: 4 },
-            function (error, l, c) { literals = l, totalCount = c; done(error); });
+        before(function () {
+          return document.searchLiterals('b', { offset: 4 }).then(result => {
+            literals = result.literals;
+            totalCount = result.totalCount;
+          });
         });
+
 
         it('should return literals containing "b"', function () {
           literals.should.eql(['"bc"^^bcd', '"abc"^^bcd', '"bc"^^bcd', '"a"^^bcd', '"abc"^^bcd']);
@@ -966,9 +932,11 @@ describe('hdt', function () {
 
       describe('for the literal "b" with a very large offset', function () {
         var literals, totalCount;
-        before(function (done) {
-          document.searchLiterals('b', { offset: 5000 },
-            function (error, l, c) { literals = l, totalCount = c; done(error); });
+        before(function () {
+          return document.searchLiterals('b', { offset: 5000 }).then(result => {
+            literals = result.literals;
+            totalCount = result.totalCount;
+          });
         });
 
         it('should return the empty array', function () {
@@ -983,10 +951,13 @@ describe('hdt', function () {
 
     describe('for the literal "b" with an offset and a limit', function () {
       var literals, totalCount;
-      before(function (done) {
-        document.searchLiterals('b', { offset: 4, limit: 2 },
-          function (error, l, c) { literals = l, totalCount = c; done(error); });
+      before(function () {
+        return document.searchLiterals('b', { offset: 4, limit: 2 }).then(result => {
+          literals = result.literals;
+          totalCount = result.totalCount;
+        });
       });
+
 
       it('should return literals containing "b"', function () {
         literals.should.eql(['"bc"^^bcd', '"abc"^^bcd']);
@@ -999,32 +970,34 @@ describe('hdt', function () {
   });
   describe('A closed HDT document', function () {
     var document;
-    before(function (done) {
-      hdt.fromFile('./test/test.hdt', function (error, hdtDocument) {
+    before(function () {
+      return hdt.fromFile('./test/test.hdt').then(hdtDocument => {
         document = hdtDocument;
-        document.close(done);
+        return document.close();
       });
     });
 
     describe('being searched for triples', function () {
-      it('should throw an error', function (done) {
-        document.searchTriples(null, null, null, function (error) {
-          this.should.equal(document);
-          error.should.be.an.instanceOf(Error);
-          error.message.should.equal('The HDT document cannot be read because it is closed');
-          done();
-        });
+      it('should throw an error', function () {
+        return document.searchTriples(null, null, null).then(
+          () => Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('The HDT document cannot be read because it is closed');
+          }
+        );
       });
     });
 
     describe('being searched for literals', function () {
-      it('should throw an error', function (done) {
-        document.searchLiterals('abc', function (error) {
-          this.should.equal(document);
-          error.should.be.an.instanceOf(Error);
-          error.message.should.equal('The HDT document cannot be read because it is closed');
-          done();
-        });
+      it('should throw an error', function () {
+        return document.searchLiterals('abc').then(
+          () => Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('The HDT document cannot be read because it is closed');
+          }
+        );
       });
     });
   });

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -12,7 +12,7 @@ describe('hdt', function () {
   describe('creating a new HDT document with fromFile', function () {
     describe('with a non-string argument', function () {
       it('should throw an error', function () {
-        return hdt.fromFile(null).then(() => Promise.reject(new Error('Expected an error')), (error) => {
+        return hdt.fromFile(null).then(() => Promise.reject(new Error('Expected an error')), error => {
           error.should.be.an.Error;
           error.message.should.equal('Invalid filename: null');
         });
@@ -21,7 +21,7 @@ describe('hdt', function () {
 
     describe('with a non-existing file as argument', function () {
       it('should throw an error', function () {
-        return hdt.fromFile('abc').then(() => Promise.reject(new Error('Expected an error')), (error) => {
+        return hdt.fromFile('abc').then(() => Promise.reject(new Error('Expected an error')), error => {
           error.should.be.an.Error;
           error.message.should.equal('Could not open HDT file "abc"');
         });
@@ -30,7 +30,7 @@ describe('hdt', function () {
 
     describe('with a non-HDT file as argument', function () {
       it('should throw an error', function () {
-        return hdt.fromFile('./test/hdt-test.js').then(() => Promise.reject(new Error('Expected an error')), (error) => {
+        return hdt.fromFile('./test/hdt-test.js').then(() => Promise.reject(new Error('Expected an error')), error => {
           error.should.be.an.Error;
           error.message.should.equal('The file "./test/hdt-test.js" is not a valid HDT file');
         });
@@ -108,7 +108,7 @@ describe('hdt', function () {
       it('Should throw on invalid position', function () {
         return document.searchTerms({ prefix: 'http://example.org/', limit: 'sdf', position: 'bla' }).then(
           () => Promise.reject(new Error('Expected an error')),
-          (error) => {
+          error => {
             error.should.be.an.instanceOf(Error);
             error.message.should.equal('Invalid position argument. Expected subject, predicate or object.');
           }
@@ -758,7 +758,7 @@ describe('hdt', function () {
       it('should throw an error', function () {
         return document.searchLiterals('abc').then(
           () => Promise.reject(new Error('expected an error')),
-          (error) => {
+          error => {
             error.should.be.an.instanceOf(Error);
             error.message.should.equal('The HDT document does not support literal search');
           }
@@ -979,8 +979,8 @@ describe('hdt', function () {
 
     describe('being searched for triples', function () {
       it('should throw an error', function () {
-        return document.searchTriples(null, null, null).then(
-          () => Promise.reject(new Error('Expected an error')),
+        return document.searchTriples(null, null, null).then(() =>
+            Promise.reject(new Error('Expected an error')),
           error => {
             error.should.be.an.instanceOf(Error);
             error.message.should.equal('The HDT document cannot be read because it is closed');
@@ -991,8 +991,8 @@ describe('hdt', function () {
 
     describe('being searched for literals', function () {
       it('should throw an error', function () {
-        return document.searchLiterals('abc').then(
-          () => Promise.reject(new Error('Expected an error')),
+        return document.searchLiterals('abc').then(() =>
+            Promise.reject(new Error('Expected an error')),
           error => {
             error.should.be.an.instanceOf(Error);
             error.message.should.equal('The HDT document cannot be read because it is closed');


### PR DESCRIPTION
What changed:

- Callbacks are converted to (or wrapped as) Promises
- Often multiple arguments were given in the callback function (e.g. `triples`, `totalCount`, `hasExactCount`). As promises should return only one value, I wrapped these in an object. 
- Changed some `var` keywords to `const` if applicable
- Modified eslint config to target es6, and to recognize promises as globals
- Removed the `self` reference that were bound to the callbacks. Don't believe there is much need for them anymore with arrow functions, promises, and (on more recent versions of nodejs) async/await.

I planned on transforming the `prototype` functions to a regular es6 class, but that won't do us any good as we shouldnt create our own class, but simply extend the native class by assiging extra functions to its prototype.