### PR TITLE
Apply travis on packaged hdt, to avoid issues caused by ignore files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ install:
   - if [ $TRAVIS_OS_NAME == linux ]; then
       export CXX=g++-4.8;
     fi
+  - npm pack .
+  - tar -xzf hdt-*.tgz
+  - cd package
   - npm install
 script:
   - npm run lint


### PR DESCRIPTION
Seems to catch the bug that the previous travis built let pass: https://travis-ci.org/RubenVerborgh/HDT-Node/jobs/330272790