### PR TITLE
Add read and write of header

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ hdt.fromFile('./test/test.hdt')
     console.error(e);
   })
 ```
-### Writing a new header
-To write header information to an HDT, use `document.writeHeader(toFile, header)`, that returns an HDT document of the output file.
+### Changing the header
+To replace header information of an HDT, use `document.changeHeader(header, toFile)`, that returns an HDT document of the output file.
 The example below serializes an [N3](https://github.com/RubenVerborgh/N3.js/) triples object into an N-Triples string, and stores it in the header.
 
 ```JavaScript
@@ -163,7 +163,7 @@ hdt.fromFile('./test/test.hdt')
    });
  })
  .then(function(triples) {
-      return doc.writeHeader(outputFile, triples);
+      return doc.changeHeader(triples, outputFile);
   })
   .then(function(createdDocument) {
     return createdDocument.readHeader();

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -56,7 +56,7 @@ const Nan::Persistent<Function>& HdtDocument::GetConstructor() {
     Nan::SetPrototypeMethod(constructorTemplate, "_searchLiterals", SearchLiterals);
     Nan::SetPrototypeMethod(constructorTemplate, "_searchTerms",    SearchTerms);
     Nan::SetPrototypeMethod(constructorTemplate, "_readHeader",     ReadHeader);
-    Nan::SetPrototypeMethod(constructorTemplate, "_writeHeader",    WriteHeader);
+    Nan::SetPrototypeMethod(constructorTemplate, "_changeHeader",   ChangeHeader);
     Nan::SetPrototypeMethod(constructorTemplate, "_close",          Close);
     Nan::SetAccessor(constructorTemplate->PrototypeTemplate(),
                      Nan::New("_features").ToLocalChecked(), Features);
@@ -439,9 +439,9 @@ NAN_METHOD(HdtDocument::ReadHeader) {
     info[1]->IsObject() ? info[1].As<Object>() : info.This()));
 }
 
-/******** HdtDocument#_writeHeader ********/
+/******** HdtDocument#_changeHeader ********/
 
-class WriteHeaderWorker : public Nan::AsyncWorker {
+class ChangeHeaderWorker : public Nan::AsyncWorker {
   HdtDocument* document;
   // JavaScript function arguments
   Persistent<Object> self;
@@ -449,10 +449,10 @@ class WriteHeaderWorker : public Nan::AsyncWorker {
   string outputFile;
 
 public:
-  WriteHeaderWorker(HdtDocument* document, string outputFile, string headerString,
+  ChangeHeaderWorker(HdtDocument* document, string headerString, string outputFile,
                     Nan::Callback* callback, Local<Object> self)
     : Nan::AsyncWorker(callback), document(document),
-      outputFile(outputFile), headerString(headerString) {
+      headerString(headerString), outputFile(outputFile) {
         SaveToPersistent("self", self);
     };
 
@@ -490,11 +490,11 @@ public:
 };
 
 // Replaces the current header with a new one and saves result to a new file.
-// JavaScript signature: HdtDocument#_writeHeader(outputFile, header, callback, self)
-NAN_METHOD(HdtDocument::WriteHeader) {
+// JavaScript signature: HdtDocument#_changeHeader(header, outputFile, callback, self)
+NAN_METHOD(HdtDocument::ChangeHeader) {
   assert(info.Length() == 4);
 
-  Nan::AsyncQueueWorker(new WriteHeaderWorker(Unwrap<HdtDocument>(info.This()),
+  Nan::AsyncQueueWorker(new ChangeHeaderWorker(Unwrap<HdtDocument>(info.This()),
     *Nan::Utf8String(info[0]), *Nan::Utf8String(info[1]),
     new Nan::Callback(info[2].As<Function>()),
     info[3]->IsObject() ? info[3].As<Object>() : info.This()));

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -403,6 +403,8 @@ public:
         headerString += ts->getObject();
         headerString += " .\n";
   		}
+      // Remove last newline.
+      headerString.pop_back();
     }
     catch (const runtime_error error) { SetErrorMessage(error.what()); }
     if (it)

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -386,7 +386,7 @@ public:
     , document(document)
     , headerString("") {
       SaveToPersistent("self", self);
-    };
+  };
 
   void Execute() {
     IteratorTripleString *it = NULL;

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -382,14 +382,15 @@ class ReadHeaderWorker : public Nan::AsyncWorker {
 
 public:
   ReadHeaderWorker(HdtDocument* document, Nan::Callback* callback, Local<Object> self)
-    : Nan::AsyncWorker(callback), document(document), headerString("") {
-        SaveToPersistent("self", self);
+    : Nan::AsyncWorker(callback)
+    , document(document)
+    , headerString("") {
+      SaveToPersistent("self", self);
     };
 
   void Execute() {
     IteratorTripleString *it = NULL;
     try {
-
       Header *header = document->GetHDT()->getHeader();
       IteratorTripleString *it = header->search("","","");
 
@@ -468,7 +469,7 @@ public:
   		header->load(in, ci);
 
       // Save
-  		document->GetHDT()->saveToHDT(outputFile.c_str());
+      document->GetHDT()->saveToHDT(outputFile.c_str());
     }
     catch (const runtime_error error) { SetErrorMessage(error.what()); }
   }

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -446,13 +446,13 @@ class WriteHeaderWorker : public Nan::AsyncWorker {
   // JavaScript function arguments
   Persistent<Object> self;
   string headerString;
-  string fileName;
+  string outputFile;
 
 public:
-  WriteHeaderWorker(HdtDocument* document, string headerString, string fileName,
+  WriteHeaderWorker(HdtDocument* document, string headerString, string outputFile,
                     Nan::Callback* callback, Local<Object> self)
     : Nan::AsyncWorker(callback), document(document),
-      headerString(headerString), fileName(fileName) {
+      headerString(headerString), outputFile(outputFile) {
         SaveToPersistent("self", self);
     };
 
@@ -470,7 +470,7 @@ public:
   		header->load(in, ci);
 
       // Save
-  		document->GetHDT()->saveToHDT(this->fileName.c_str());
+  		document->GetHDT()->saveToHDT(outputFile.c_str());
     }
     catch (const runtime_error error) { SetErrorMessage(error.what()); }
   }
@@ -489,8 +489,8 @@ public:
   }
 };
 
-// Replaces the current header with a new one.
-// JavaScript signature: HdtDocument#_writeHeader(header, filename, callback, self)
+// Replaces the current header with a new one and saves result to a new file.
+// JavaScript signature: HdtDocument#_writeHeader(header, outputFile, callback, self)
 NAN_METHOD(HdtDocument::WriteHeader) {
   assert(info.Length() == 4);
 

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -449,10 +449,10 @@ class WriteHeaderWorker : public Nan::AsyncWorker {
   string outputFile;
 
 public:
-  WriteHeaderWorker(HdtDocument* document, string headerString, string outputFile,
+  WriteHeaderWorker(HdtDocument* document, string outputFile, string headerString,
                     Nan::Callback* callback, Local<Object> self)
     : Nan::AsyncWorker(callback), document(document),
-      headerString(headerString), outputFile(outputFile) {
+      outputFile(outputFile), headerString(headerString) {
         SaveToPersistent("self", self);
     };
 
@@ -490,7 +490,7 @@ public:
 };
 
 // Replaces the current header with a new one and saves result to a new file.
-// JavaScript signature: HdtDocument#_writeHeader(header, outputFile, callback, self)
+// JavaScript signature: HdtDocument#_writeHeader(outputFile, header, callback, self)
 NAN_METHOD(HdtDocument::WriteHeader) {
   assert(info.Length() == 4);
 

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -379,11 +379,10 @@ class ReadHeaderWorker : public Nan::AsyncWorker {
   Persistent<Object> self;
   // Callback return values
   string headerString;
-  uint32_t totalCount;
 
 public:
   ReadHeaderWorker(HdtDocument* document, Nan::Callback* callback, Local<Object> self)
-    : Nan::AsyncWorker(callback), document(document), headerString(""), totalCount(0) {
+    : Nan::AsyncWorker(callback), document(document), headerString("") {
         SaveToPersistent("self", self);
     };
 
@@ -403,7 +402,6 @@ public:
         headerString += " ";
         headerString += ts->getObject();
         headerString += " .\n";
-        totalCount++;
   		}
     }
     catch (const runtime_error error) { SetErrorMessage(error.what()); }
@@ -417,10 +415,9 @@ public:
     // Convert header string to Local<String>.
     Local<String> nanHeader = Nan::New(headerString).ToLocalChecked();
 
-    // Send the header git string and total count through the callback.
-    const unsigned argc = 3;
-    Local<Value> argv[argc] = { Nan::Null(), nanHeader,
-                                Nan::New<Integer>((uint32_t)totalCount)};
+    // Send the header string through the callback.
+    const unsigned argc = 2;
+    Local<Value> argv[argc] = { Nan::Null(), nanHeader };
     callback->Call(GetFromPersistent("self")->ToObject(), argc, argv);
   }
 

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -403,8 +403,6 @@ public:
         headerString += ts->getObject();
         headerString += " .\n";
   		}
-      // Remove last newline.
-      headerString.pop_back();
     }
     catch (const runtime_error error) { SetErrorMessage(error.what()); }
     if (it)

--- a/lib/HdtDocument.h
+++ b/lib/HdtDocument.h
@@ -36,6 +36,8 @@ class HdtDocument : public node::ObjectWrap {
   static NAN_METHOD(SearchLiterals);
   // HdtDocument#_searchTerms()
   static NAN_METHOD(SearchTerms);
+  // HdtDocument#_readHeader()
+  static NAN_METHOD(ReadHeader);
   // HdtDocument#_features
   static NAN_PROPERTY_GETTER(Features);
   // HdtDocument#close([callback], [self])

--- a/lib/HdtDocument.h
+++ b/lib/HdtDocument.h
@@ -36,9 +36,9 @@ class HdtDocument : public node::ObjectWrap {
   static NAN_METHOD(SearchLiterals);
   // HdtDocument#_searchTerms()
   static NAN_METHOD(SearchTerms);
-  // HdtDocument#_readHeader()
+  // HdtDocument#_readHeader(callback, self)
   static NAN_METHOD(ReadHeader);
-  // HdtDocument#_writeHeader()
+  // HdtDocument#_writeHeader(headerString, filename, callback, self)
   static NAN_METHOD(WriteHeader);
   // HdtDocument#_features
   static NAN_PROPERTY_GETTER(Features);

--- a/lib/HdtDocument.h
+++ b/lib/HdtDocument.h
@@ -38,8 +38,8 @@ class HdtDocument : public node::ObjectWrap {
   static NAN_METHOD(SearchTerms);
   // HdtDocument#_readHeader(callback, self)
   static NAN_METHOD(ReadHeader);
-  // HdtDocument#_writeHeader(outputFile, headerString, callback, self)
-  static NAN_METHOD(WriteHeader);
+  // HdtDocument#_changeHeader(headerString, outputFile, callback, self)
+  static NAN_METHOD(ChangeHeader);
   // HdtDocument#_features
   static NAN_PROPERTY_GETTER(Features);
   // HdtDocument#close([callback], [self])

--- a/lib/HdtDocument.h
+++ b/lib/HdtDocument.h
@@ -38,6 +38,8 @@ class HdtDocument : public node::ObjectWrap {
   static NAN_METHOD(SearchTerms);
   // HdtDocument#_readHeader()
   static NAN_METHOD(ReadHeader);
+  // HdtDocument#_writeHeader()
+  static NAN_METHOD(WriteHeader);
   // HdtDocument#_features
   static NAN_PROPERTY_GETTER(Features);
   // HdtDocument#close([callback], [self])

--- a/lib/HdtDocument.h
+++ b/lib/HdtDocument.h
@@ -38,7 +38,7 @@ class HdtDocument : public node::ObjectWrap {
   static NAN_METHOD(SearchTerms);
   // HdtDocument#_readHeader(callback, self)
   static NAN_METHOD(ReadHeader);
-  // HdtDocument#_writeHeader(headerString, filename, callback, self)
+  // HdtDocument#_writeHeader(headerString, outputFile, callback, self)
   static NAN_METHOD(WriteHeader);
   // HdtDocument#_features
   static NAN_PROPERTY_GETTER(Features);

--- a/lib/HdtDocument.h
+++ b/lib/HdtDocument.h
@@ -38,7 +38,7 @@ class HdtDocument : public node::ObjectWrap {
   static NAN_METHOD(SearchTerms);
   // HdtDocument#_readHeader(callback, self)
   static NAN_METHOD(ReadHeader);
-  // HdtDocument#_writeHeader(headerString, outputFile, callback, self)
+  // HdtDocument#_writeHeader(outputFile, headerString, callback, self)
   static NAN_METHOD(WriteHeader);
   // HdtDocument#_features
   static NAN_PROPERTY_GETTER(Features);

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -83,15 +83,13 @@ HdtDocumentPrototype.readHeader = function () {
 
 // Replaces the current header with a new one.
 HdtDocumentPrototype.writeHeader = function (header) {
-  if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
-  var keys;
+  if (this.closed) return Promise.reject(new Error('The HDT document cannot be written because it is closed'));
+  // Do some validation of the triples
   for (var i = 0; i < header.length; i++) {
-    keys = Object.keys(header[i]);
-    if (keys.length !== 3) return Promise.reject(new Error('Bad format of given header'));
-    if (keys.indexOf('subject') === -1) return Promise.reject(new Error('Bad format of given header'));
-    if (keys.indexOf('predicate') === -1) return Promise.reject(new Error('Bad format of given header'));
-    if (keys.indexOf('object') === -1) return Promise.reject(new Error('Bad format of given header'));
-    if (header[i].subject === '' || header[i].predicate === '' || header[i].object === '') return Promise.reject(new Error('Bad format of given header'));
+    if (Object.keys(header[i]).length !== 3) return Promise.reject(new Error('Bad format of statement at index ' + i));
+    if (!header[i].subject) return Promise.reject(new Error('Missing subject at index ' + i));
+    if (!header[i].predicate) return Promise.reject(new Error('Missing predicate at index ' + i));
+    if (!header[i].object) return Promise.reject(new Error('Missing object at index ' + i));
   }
   return new Promise((resolve, reject) => {
     this._writeHeader(header, (error) => {

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -67,6 +67,17 @@ HdtDocumentPrototype.searchTerms = function (options) {
     }, this);
   });
 };
+HdtDocumentPrototype.readHeader = function () {
+  if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
+  return new Promise((resolve, reject) => {
+    this._readHeader((error, triples, totalCount) => {
+      if (error)
+        reject(error);
+      else
+        resolve({ triples, totalCount });
+    }, this);
+  });
+};
 HdtDocumentPrototype.close = function () {
   return new Promise((resolve, reject) => {
     this._close(function (err) {
@@ -110,6 +121,7 @@ module.exports = {
           searchTriples:  true, // supported by default
           countTriples:   true, // supported by default
           searchLiterals: !!(document._features & 1),
+          readHeader:     true,
         });
         resolve(document);
       });

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -84,13 +84,6 @@ HdtDocumentPrototype.readHeader = function () {
 // Replaces the current header with a new one.
 HdtDocumentPrototype.writeHeader = function (header) {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be written because it is closed'));
-  // Do some validation of the triples
-  for (var i = 0; i < header.length; i++) {
-    if (Object.keys(header[i]).length !== 3) return Promise.reject(new Error('Bad format of statement at index ' + i));
-    if (!header[i].subject) return Promise.reject(new Error('Missing subject at index ' + i));
-    if (!header[i].predicate) return Promise.reject(new Error('Missing predicate at index ' + i));
-    if (!header[i].object) return Promise.reject(new Error('Missing object at index ' + i));
-  }
   return new Promise((resolve, reject) => {
     this._writeHeader(header, (error) => {
       if (error)

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -140,6 +140,7 @@ module.exports = {
           readHeader:     true, // supported by default
           writeHeader:    true, // supported by default
         });
+        document.filename = filename;
         resolve(document);
       });
     });

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -85,7 +85,7 @@ HdtDocumentPrototype.readHeader = function () {
 HdtDocumentPrototype.writeHeader = function (header) {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be written because it is closed'));
   return new Promise((resolve, reject) => {
-    this._writeHeader(header, (error) => {
+    this._writeHeader(header, this.filename, (error) => {
       if (error)
         reject(error);
       else

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -68,15 +68,15 @@ HdtDocumentPrototype.searchTerms = function (options) {
   });
 };
 
-// Returns the header of the HDT document as an array of triples.
+// Returns the header of the HDT document as a string.
 HdtDocumentPrototype.readHeader = function () {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
   return new Promise((resolve, reject) => {
-    this._readHeader((error, triples, totalCount) => {
+    this._readHeader((error, header, totalCount) => {
       if (error)
         reject(error);
       else
-        resolve(triples);
+        resolve(header);
     }, this);
   });
 };

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -72,12 +72,7 @@ HdtDocumentPrototype.searchTerms = function (options) {
 HdtDocumentPrototype.readHeader = function () {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
   return new Promise((resolve, reject) => {
-    this._readHeader((error, header) => {
-      if (error)
-        reject(error);
-      else
-        resolve(header);
-    }, this);
+    this._readHeader((e, header) => e ? reject(e) : resolve(header), this);
   });
 };
 
@@ -85,12 +80,7 @@ HdtDocumentPrototype.readHeader = function () {
 HdtDocumentPrototype.writeHeader = function (header) {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be written because it is closed'));
   return new Promise((resolve, reject) => {
-    this._writeHeader(header, this.filename, (error) => {
-      if (error)
-        reject(error);
-      else
-        resolve();
-    }, this);
+    this._writeHeader(header, this.filename, e => e ? reject(e) : resolve(), this);
   }).then(() => this.readHeader());
 };
 

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -72,7 +72,7 @@ HdtDocumentPrototype.searchTerms = function (options) {
 HdtDocumentPrototype.readHeader = function () {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
   return new Promise((resolve, reject) => {
-    this._readHeader((error, header, totalCount) => {
+    this._readHeader((error, header) => {
       if (error)
         reject(error);
       else

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -44,7 +44,7 @@ HdtDocumentPrototype.searchLiterals = function (substring, options) {
   });
 };
 
-// Searches the document for literals that contain the given string
+// Searches the document for literals that contain the given string.
 const POSITIONS = {
   subject: 0,
   predicate: 1,
@@ -67,6 +67,8 @@ HdtDocumentPrototype.searchTerms = function (options) {
     }, this);
   });
 };
+
+// Returns the header of the HDT document as an array of triples.
 HdtDocumentPrototype.readHeader = function () {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
   return new Promise((resolve, reject) => {
@@ -74,10 +76,33 @@ HdtDocumentPrototype.readHeader = function () {
       if (error)
         reject(error);
       else
-        resolve({ triples, totalCount });
+        resolve(triples);
     }, this);
   });
 };
+
+// Replaces the current header with a new one.
+HdtDocumentPrototype.writeHeader = function (header) {
+  if (this.closed) return Promise.reject(new Error('The HDT document cannot be read because it is closed'));
+  var keys;
+  for (var i = 0; i < header.length; i++) {
+    keys = Object.keys(header[i]);
+    if (keys.length !== 3) return Promise.reject(new Error('Bad format of given header'));
+    if (keys.indexOf('subject') === -1) return Promise.reject(new Error('Bad format of given header'));
+    if (keys.indexOf('predicate') === -1) return Promise.reject(new Error('Bad format of given header'));
+    if (keys.indexOf('object') === -1) return Promise.reject(new Error('Bad format of given header'));
+    if (header[i].subject === '' || header[i].predicate === '' || header[i].object === '') return Promise.reject(new Error('Bad format of given header'));
+  }
+  return new Promise((resolve, reject) => {
+    this._writeHeader(header, (error) => {
+      if (error)
+        reject(error);
+      else
+        resolve();
+    }, this);
+  }).then(() => this.readHeader());
+};
+
 HdtDocumentPrototype.close = function () {
   return new Promise((resolve, reject) => {
     this._close(function (err) {
@@ -121,7 +146,8 @@ module.exports = {
           searchTriples:  true, // supported by default
           countTriples:   true, // supported by default
           searchLiterals: !!(document._features & 1),
-          readHeader:     true,
+          readHeader:     true, // supported by default
+          writeHeader:    true, // supported by default
         });
         resolve(document);
       });

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -77,11 +77,11 @@ HdtDocumentPrototype.readHeader = function () {
 };
 
 // Replaces the current header with a new one and saves result to a new file.
-HdtDocumentPrototype.writeHeader = function (header, outputFile) {
+HdtDocumentPrototype.writeHeader = function (outputFile, header) {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be written because it is closed'));
   return new Promise((resolve, reject) => {
-    this._writeHeader(header, outputFile, e => e ? reject(e) : resolve(), this);
-  }).then(() => this.readHeader());
+    this._writeHeader(outputFile, header, e => e ? reject(e) : resolve(), this);
+  }).then(() => module.exports.fromFile(outputFile));
 };
 
 HdtDocumentPrototype.close = function () {

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -76,11 +76,11 @@ HdtDocumentPrototype.readHeader = function () {
   });
 };
 
-// Replaces the current header with a new one.
-HdtDocumentPrototype.writeHeader = function (header) {
+// Replaces the current header with a new one and saves result to a new file.
+HdtDocumentPrototype.writeHeader = function (header, outputFile) {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be written because it is closed'));
   return new Promise((resolve, reject) => {
-    this._writeHeader(header, this.filename, e => e ? reject(e) : resolve(), this);
+    this._writeHeader(header, outputFile, e => e ? reject(e) : resolve(), this);
   }).then(() => this.readHeader());
 };
 
@@ -130,7 +130,6 @@ module.exports = {
           readHeader:     true, // supported by default
           writeHeader:    true, // supported by default
         });
-        document.filename = filename;
         resolve(document);
       });
     });

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -44,7 +44,7 @@ HdtDocumentPrototype.searchLiterals = function (substring, options) {
   });
 };
 
-// Searches the document for literals that contain the given string.
+// Searches terms based on a given prefix string.
 const POSITIONS = {
   subject: 0,
   predicate: 1,

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -77,10 +77,10 @@ HdtDocumentPrototype.readHeader = function () {
 };
 
 // Replaces the current header with a new one and saves result to a new file.
-HdtDocumentPrototype.writeHeader = function (outputFile, header) {
+HdtDocumentPrototype.changeHeader = function (header, outputFile) {
   if (this.closed) return Promise.reject(new Error('The HDT document cannot be written because it is closed'));
   return new Promise((resolve, reject) => {
-    this._writeHeader(outputFile, header, e => e ? reject(e) : resolve(), this);
+    this._changeHeader(header, outputFile, e => e ? reject(e) : resolve(), this);
   }).then(() => module.exports.fromFile(outputFile));
 };
 
@@ -128,7 +128,7 @@ module.exports = {
           countTriples:   true, // supported by default
           searchLiterals: !!(document._features & 1),
           readHeader:     true, // supported by default
-          writeHeader:    true, // supported by default
+          changeHeader:    true, // supported by default
         });
         resolve(document);
       });

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,1 @@
+testOutput.hdt*

--- a/test/.tmp/.gitignore
+++ b/test/.tmp/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/test/.tmp/.gitignore
+++ b/test/.tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -84,7 +84,7 @@ describe('hdt', function () {
       });
       it('should return a string with matches', function () {
         header.should.be.a.String();
-        header.split('\n').should.have.length(22);
+        header.split('\n').should.have.length(23);
         header.indexOf('<file://test/test.ttl> ' +
                        '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ' +
                        '<http://purl.org/HDT/hdt#Dataset>').should.be.above(-1);
@@ -118,7 +118,7 @@ describe('hdt', function () {
         });
         it('should return a string with matches', function () {
           header.should.be.a.String();
-          header.split('\n').should.have.length(2);
+          header.split('\n').should.have.length(3);
           header.indexOf('_:dictionary ' +
                          '<http://purl.org/HDT/hdt#dictionarymapping> ' +
                          '"1"').should.be.above(-1);
@@ -953,7 +953,7 @@ describe('hdt', function () {
       });
       it('should return a string with matches', function () {
         header.should.be.a.String();
-        header.split('\n').should.have.length(28);
+        header.split('\n').should.have.length(29);
         header.indexOf('<file://literals.ttl> ' +
                        '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ' +
                        '<http://purl.org/HDT/hdt#Dataset>').should.be.above(-1);

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -65,6 +65,14 @@ describe('hdt', function () {
       it('should not support searchLiterals', function () {
         document.features.searchLiterals.should.be.false();
       });
+
+      it('should support readHeader', function () {
+        document.features.readHeader.should.be.true();
+      });
+
+      it('should support writeHeader', function () {
+        document.features.writeHeader.should.be.true();
+      });
     });
 
     describe('reading the header', function () {
@@ -86,7 +94,7 @@ describe('hdt', function () {
       });
     });
 
-    describe.only('writing a header and saving to a new file', function () {
+    describe('writing a header and saving to a new file', function () {
       var newhdt;
       var header = '_:dictionary <http://purl.org/HDT/hdt#dictionarymapping> "1" .\n' +
                    '_:dictionary <http://purl.org/HDT/hdt#dictionarysizeStrings> "825" .';
@@ -925,6 +933,14 @@ describe('hdt', function () {
 
       it('should support searchLiterals', function () {
         document.features.searchLiterals.should.be.true();
+      });
+
+      it('should support readHeader', function () {
+        document.features.readHeader.should.be.true();
+      });
+
+      it('should support writeHeader', function () {
+        document.features.writeHeader.should.be.true();
       });
     });
 

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -41,6 +41,7 @@ describe('hdt', function () {
   describe('modifying an HDT header', function () {
     var document;
     before(function () {
+      // We're modifying the hdt, so copy it to a different location first
       return new Promise((resolve, reject) => {
         fs.createReadStream('./test/test.hdt')
           .on('error', reject)
@@ -52,6 +53,10 @@ describe('hdt', function () {
         .then(hdtDocument => {
           document = hdtDocument;
         });
+    });
+
+    after(function () {
+      return document.close();
     });
 
     describe('reading, modifying and writing a new header', function () {
@@ -66,9 +71,6 @@ describe('hdt', function () {
           .then(result => {
             newHeader = result;
           });
-      });
-      after(function () {
-        return document.close();
       });
 
       it('should return an array of the new header triples', function () {

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -1,7 +1,7 @@
 require('should');
 
 var hdt = require('../lib/hdt');
-var fs = require('fs');
+
 describe('hdt', function () {
   describe('The hdt module', function () {
     it('should be an object', function () {
@@ -36,58 +36,6 @@ describe('hdt', function () {
         });
       });
     });
-  });
-
-  describe('modifying an HDT header', function () {
-    var document;
-    before(function () {
-      // We're modifying the hdt, so copy it to a different location first
-      return new Promise((resolve, reject) => {
-        fs.createReadStream('./test/test.hdt')
-          .on('error', reject)
-          .pipe(fs.createWriteStream('./test/.tmp/test.hdt'))
-          .on('error', reject)
-          .on('finish', resolve);
-      })
-        .then(() => hdt.fromFile('./test/.tmp/test.hdt'))
-        .then(hdtDocument => {
-          document = hdtDocument;
-        });
-    });
-
-    after(function () {
-      return document.close();
-    });
-
-    // describe('reading, modifying and writing a new header', function () {
-    //   var oldHeader, newHeader;
-    //   before(function () {
-    //     return document.readHeader()
-    //       .then(result => {
-    //         oldHeader = result.slice();
-    //         result.splice(0, 1);
-    //         return document.writeHeader(result);
-    //       })
-    //       .then(result => {
-    //         newHeader = result;
-    //       });
-    //   });
-    //
-    //   it('should return an array of the new header triples', function () {
-    //     newHeader.should.be.an.Array();
-    //     newHeader.should.have.length(21);
-    //     newHeader[0].should.eql({
-    //       subject:   '<file://test/test.ttl>',
-    //       predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-    //       object:    '<http://rdfs.org/ns/void#Dataset>'  });
-    //     newHeader[1].should.eql({
-    //       subject:   '<file://test/test.ttl>',
-    //       predicate: '<http://rdfs.org/ns/void#triples>',
-    //       object:    '"132"'  });
-    //     oldHeader.should.be.an.Array();
-    //     oldHeader.should.have.length(22);
-    //   });
-    // });
   });
 
   describe('An HDT document for an example HDT file', function () {
@@ -135,6 +83,29 @@ describe('hdt', function () {
         header.indexOf('_:publicationInformation ' +
                        '<http://purl.org/dc/terms/issued> ' +
                        '"2014-10-08T16:16:03+0200"').should.be.above(-1);
+      });
+    });
+
+    describe('writing a new header and saving to a new file', function () {
+      var newHeader;
+      var header = '_:dictionary <http://purl.org/HDT/hdt#dictionarymapping> "1" .\n' +
+                   '_:dictionary <http://purl.org/HDT/hdt#dictionarysizeStrings> "825" .';
+      var outputFile = './test/testOutput.hdt';
+      before(function () {
+        return document.writeHeader(header, outputFile)
+          .then(result => {
+            newHeader = result;
+          });
+      });
+      it('should return a string of the new header', function () {
+        newHeader.should.be.a.String();
+        newHeader.split('\n').should.have.length(2);
+        newHeader.indexOf('_:dictionary ' +
+                       '<http://purl.org/HDT/hdt#dictionarymapping> ' +
+                       '"1"').should.be.above(-1);
+        newHeader.indexOf('_:dictionary ' +
+                       '<http://purl.org/HDT/hdt#dictionarysizeStrings> ' +
+                       '"825"').should.be.above(-1);
       });
     });
 

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -70,8 +70,8 @@ describe('hdt', function () {
         document.features.readHeader.should.be.true();
       });
 
-      it('should support writeHeader', function () {
-        document.features.writeHeader.should.be.true();
+      it('should support changeHeader', function () {
+        document.features.changeHeader.should.be.true();
       });
     });
 
@@ -100,7 +100,7 @@ describe('hdt', function () {
                    '_:dictionary <http://purl.org/HDT/hdt#dictionarysizeStrings> "825" .';
       var outputFile = './test/testOutput.hdt';
       before(function () {
-        return document.writeHeader(outputFile, header)
+        return document.changeHeader(header, outputFile)
           .then(hdtDocument => {
             newhdt = hdtDocument;
           });
@@ -939,8 +939,8 @@ describe('hdt', function () {
         document.features.readHeader.should.be.true();
       });
 
-      it('should support writeHeader', function () {
-        document.features.writeHeader.should.be.true();
+      it('should support changeHeader', function () {
+        document.features.changeHeader.should.be.true();
       });
     });
 

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -59,35 +59,35 @@ describe('hdt', function () {
       return document.close();
     });
 
-    describe('reading, modifying and writing a new header', function () {
-      var oldHeader, newHeader;
-      before(function () {
-        return document.readHeader()
-          .then(result => {
-            oldHeader = result.slice();
-            result.splice(0, 1);
-            return document.writeHeader(result);
-          })
-          .then(result => {
-            newHeader = result;
-          });
-      });
-
-      it('should return an array of the new header triples', function () {
-        newHeader.should.be.an.Array();
-        newHeader.should.have.length(21);
-        newHeader[0].should.eql({
-          subject:   '<file://test/test.ttl>',
-          predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-          object:    '<http://rdfs.org/ns/void#Dataset>'  });
-        newHeader[1].should.eql({
-          subject:   '<file://test/test.ttl>',
-          predicate: '<http://rdfs.org/ns/void#triples>',
-          object:    '"132"'  });
-        oldHeader.should.be.an.Array();
-        oldHeader.should.have.length(22);
-      });
-    });
+    // describe('reading, modifying and writing a new header', function () {
+    //   var oldHeader, newHeader;
+    //   before(function () {
+    //     return document.readHeader()
+    //       .then(result => {
+    //         oldHeader = result.slice();
+    //         result.splice(0, 1);
+    //         return document.writeHeader(result);
+    //       })
+    //       .then(result => {
+    //         newHeader = result;
+    //       });
+    //   });
+    //
+    //   it('should return an array of the new header triples', function () {
+    //     newHeader.should.be.an.Array();
+    //     newHeader.should.have.length(21);
+    //     newHeader[0].should.eql({
+    //       subject:   '<file://test/test.ttl>',
+    //       predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    //       object:    '<http://rdfs.org/ns/void#Dataset>'  });
+    //     newHeader[1].should.eql({
+    //       subject:   '<file://test/test.ttl>',
+    //       predicate: '<http://rdfs.org/ns/void#triples>',
+    //       object:    '"132"'  });
+    //     oldHeader.should.be.an.Array();
+    //     oldHeader.should.have.length(22);
+    //   });
+    // });
   });
 
   describe('An HDT document for an example HDT file', function () {
@@ -119,22 +119,22 @@ describe('hdt', function () {
       });
     });
 
-    describe('reading the Header', function () {
-      var triples;
-      before(function () {
-        return document.readHeader().then(result => {
-          triples = result;
-        });
-      });
-      it('should return an array with matches', function () {
-        triples.should.be.an.Array();
-        triples.should.have.length(22);
-        triples[0].should.eql({
-          subject: '<file://test/test.ttl>',
-          predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-          object: '<http://purl.org/HDT/hdt#Dataset>' });
-      });
-    });
+    // describe('reading the Header', function () {
+    //   var triples;
+    //   before(function () {
+    //     return document.readHeader().then(result => {
+    //       triples = result;
+    //     });
+    //   });
+    //   it('should return an array with matches', function () {
+    //     triples.should.be.an.Array();
+    //     triples.should.have.length(22);
+    //     triples[0].should.eql({
+    //       subject: '<file://test/test.ttl>',
+    //       predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    //       object: '<http://purl.org/HDT/hdt#Dataset>' });
+    //   });
+    // });
 
     describe('getting suggestions', function () {
       it('Should have correct results for predicate position', function () {
@@ -943,22 +943,22 @@ describe('hdt', function () {
       });
     });
 
-    describe('reading the Header', function () {
-      var triples;
-      before(function () {
-        return document.readHeader().then(result => {
-          triples = result;
-        });
-      });
-      it('should return an array with matches', function () {
-        triples.should.be.an.Array();
-        triples.should.have.length(28);
-        triples[0].should.eql({
-          subject: '<file://literals.ttl>',
-          predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-          object: '<http://purl.org/HDT/hdt#Dataset>' });
-      });
-    });
+    // describe('reading the Header', function () {
+    //   var triples;
+    //   before(function () {
+    //     return document.readHeader().then(result => {
+    //       triples = result;
+    //     });
+    //   });
+    //   it('should return an array with matches', function () {
+    //     triples.should.be.an.Array();
+    //     triples.should.have.length(28);
+    //     triples[0].should.eql({
+    //       subject: '<file://literals.ttl>',
+    //       predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+    //       object: '<http://purl.org/HDT/hdt#Dataset>' });
+    //   });
+    // });
 
     describe('being searched', function () {
       describe('for an existing subject', function () {
@@ -1141,17 +1141,17 @@ describe('hdt', function () {
       });
     });
 
-    describe('reading the Header', function () {
-      it('should throw an error', function () {
-        return document.readHeader().then(() =>
-            Promise.reject(new Error('Expected an error')),
-          error => {
-            error.should.be.an.instanceOf(Error);
-            error.message.should.equal('The HDT document cannot be read because it is closed');
-          }
-        );
-      });
-    });
+    // describe('reading the Header', function () {
+    //   it('should throw an error', function () {
+    //     return document.readHeader().then(() =>
+    //         Promise.reject(new Error('Expected an error')),
+    //       error => {
+    //         error.should.be.an.instanceOf(Error);
+    //         error.message.should.equal('The HDT document cannot be read because it is closed');
+    //       }
+    //     );
+    //   });
+    // });
 
     describe('being searched for triples', function () {
       it('should throw an error', function () {

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -86,26 +86,38 @@ describe('hdt', function () {
       });
     });
 
-    describe('writing a new header and saving to a new file', function () {
-      var newHeader;
+    describe.only('writing a header and saving to a new file', function () {
+      var newhdt;
       var header = '_:dictionary <http://purl.org/HDT/hdt#dictionarymapping> "1" .\n' +
                    '_:dictionary <http://purl.org/HDT/hdt#dictionarysizeStrings> "825" .';
       var outputFile = './test/testOutput.hdt';
       before(function () {
-        return document.writeHeader(header, outputFile)
-          .then(result => {
-            newHeader = result;
+        return document.writeHeader(outputFile, header)
+          .then(hdtDocument => {
+            newhdt = hdtDocument;
           });
       });
-      it('should return a string of the new header', function () {
-        newHeader.should.be.a.String();
-        newHeader.split('\n').should.have.length(2);
-        newHeader.indexOf('_:dictionary ' +
-                       '<http://purl.org/HDT/hdt#dictionarymapping> ' +
-                       '"1"').should.be.above(-1);
-        newHeader.indexOf('_:dictionary ' +
-                       '<http://purl.org/HDT/hdt#dictionarysizeStrings> ' +
-                       '"825"').should.be.above(-1);
+      after(function () {
+        return newhdt.close();
+      });
+
+      describe('reading the new header', function () {
+        var header;
+        before(function () {
+          return newhdt.readHeader().then(result => {
+            header = result;
+          });
+        });
+        it('should return a string with matches', function () {
+          header.should.be.a.String();
+          header.split('\n').should.have.length(2);
+          header.indexOf('_:dictionary ' +
+                         '<http://purl.org/HDT/hdt#dictionarymapping> ' +
+                         '"1"').should.be.above(-1);
+          header.indexOf('_:dictionary ' +
+                         '<http://purl.org/HDT/hdt#dictionarysizeStrings> ' +
+                         '"825"').should.be.above(-1);
+        });
       });
     });
 

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -67,6 +67,27 @@ describe('hdt', function () {
       });
     });
 
+    describe('reading the Header', function () {
+      var triples, totalCount;
+      before(function () {
+        return document.readHeader().then(result => {
+          triples = result.triples;
+          totalCount = result.totalCount;
+        });
+      });
+      it('should return an array with matches', function () {
+        triples.should.be.an.Array();
+        triples.should.have.length(22);
+        triples[0].should.eql({
+          subject: '<file://test/test.ttl>',
+          predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+          object: '<http://purl.org/HDT/hdt#Dataset>' });
+      });
+      it('should have a total count of 22', function () {
+        totalCount.should.equal(22);
+      });
+    });
+
     describe('getting suggestions', function () {
       it('Should have correct results for predicate position', function () {
         return document.searchTerms({ prefix: 'http://example.org/', limit:100, position : 'predicate' }).then(suggestions => {
@@ -115,6 +136,7 @@ describe('hdt', function () {
         );
       });
     });
+
     describe('being searched', function () {
       describe('with a non-existing pattern', function () {
         var triples, totalCount;
@@ -873,6 +895,27 @@ describe('hdt', function () {
       });
     });
 
+    describe('reading the Header', function () {
+      var triples, totalCount;
+      before(function () {
+        return document.readHeader().then(result => {
+          triples = result.triples;
+          totalCount = result.totalCount;
+        });
+      });
+      it('should return an array with matches', function () {
+        triples.should.be.an.Array();
+        triples.should.have.length(28);
+        triples[0].should.eql({
+          subject: '<file://literals.ttl>',
+          predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
+          object: '<http://purl.org/HDT/hdt#Dataset>' });
+      });
+      it('should have a total count of 22', function () {
+        totalCount.should.equal(28);
+      });
+    });
+
     describe('being searched', function () {
       describe('for an existing subject', function () {
         var triples, totalCount;
@@ -1051,6 +1094,18 @@ describe('hdt', function () {
       return hdt.fromFile('./test/test.hdt').then(hdtDocument => {
         document = hdtDocument;
         return document.close();
+      });
+    });
+
+    describe('reading the Header', function () {
+      it('should throw an error', function () {
+        return document.readHeader().then(() =>
+            Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('The HDT document cannot be read because it is closed');
+          }
+        );
       });
     });
 

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -1,7 +1,7 @@
 require('should');
 
 var hdt = require('../lib/hdt');
-const fs = require('fs');
+var fs = require('fs');
 describe('hdt', function () {
   describe('The hdt module', function () {
     it('should be an object', function () {

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -119,22 +119,24 @@ describe('hdt', function () {
       });
     });
 
-    // describe('reading the Header', function () {
-    //   var triples;
-    //   before(function () {
-    //     return document.readHeader().then(result => {
-    //       triples = result;
-    //     });
-    //   });
-    //   it('should return an array with matches', function () {
-    //     triples.should.be.an.Array();
-    //     triples.should.have.length(22);
-    //     triples[0].should.eql({
-    //       subject: '<file://test/test.ttl>',
-    //       predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-    //       object: '<http://purl.org/HDT/hdt#Dataset>' });
-    //   });
-    // });
+    describe('reading the header', function () {
+      var header;
+      before(function () {
+        return document.readHeader().then(result => {
+          header = result;
+        });
+      });
+      it('should return a string with matches', function () {
+        header.should.be.a.String();
+        header.split('\n').should.have.length(22);
+        header.indexOf('<file://test/test.ttl> ' +
+                       '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ' +
+                       '<http://purl.org/HDT/hdt#Dataset>').should.be.above(-1);
+        header.indexOf('_:publicationInformation ' +
+                       '<http://purl.org/dc/terms/issued> ' +
+                       '"2014-10-08T16:16:03+0200"').should.be.above(-1);
+      });
+    });
 
     describe('getting suggestions', function () {
       it('Should have correct results for predicate position', function () {
@@ -943,22 +945,24 @@ describe('hdt', function () {
       });
     });
 
-    // describe('reading the Header', function () {
-    //   var triples;
-    //   before(function () {
-    //     return document.readHeader().then(result => {
-    //       triples = result;
-    //     });
-    //   });
-    //   it('should return an array with matches', function () {
-    //     triples.should.be.an.Array();
-    //     triples.should.have.length(28);
-    //     triples[0].should.eql({
-    //       subject: '<file://literals.ttl>',
-    //       predicate: '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>',
-    //       object: '<http://purl.org/HDT/hdt#Dataset>' });
-    //   });
-    // });
+    describe('reading the header', function () {
+      var header;
+      before(function () {
+        return document.readHeader().then(result => {
+          header = result;
+        });
+      });
+      it('should return a string with matches', function () {
+        header.should.be.a.String();
+        header.split('\n').should.have.length(28);
+        header.indexOf('<file://literals.ttl> ' +
+                       '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ' +
+                       '<http://purl.org/HDT/hdt#Dataset>').should.be.above(-1);
+        header.indexOf('_:publicationInformation ' +
+                       '<http://purl.org/dc/terms/issued> ' +
+                       '"2015-02-13T17:21:30+0100"').should.be.above(-1);
+      });
+    });
 
     describe('being searched', function () {
       describe('for an existing subject', function () {
@@ -1141,17 +1145,17 @@ describe('hdt', function () {
       });
     });
 
-    // describe('reading the Header', function () {
-    //   it('should throw an error', function () {
-    //     return document.readHeader().then(() =>
-    //         Promise.reject(new Error('Expected an error')),
-    //       error => {
-    //         error.should.be.an.instanceOf(Error);
-    //         error.message.should.equal('The HDT document cannot be read because it is closed');
-    //       }
-    //     );
-    //   });
-    // });
+    describe('reading the header', function () {
+      it('should throw an error', function () {
+        return document.readHeader().then(() =>
+            Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('The HDT document cannot be read because it is closed');
+          }
+        );
+      });
+    });
 
     describe('being searched for triples', function () {
       it('should throw an error', function () {


### PR DESCRIPTION
This resolves the feature request of: https://github.com/RubenVerborgh/HDT-Node/issues/17

Two new methods were added:

1. readHeader() returns the header of an hdt file as an json array of triples.
2. writeHeader(newHeader) replaces the header of and hdt file with the newHeader. 

Some tests were also added.