### PR TITLE
Update to latest hdt-cpp version, and added (otherwise failing) test

### DIFF
--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -571,6 +571,30 @@ describe('hdt', function () {
           hasExactCount.should.equal(true);
         });
       });
+      
+      describe('with pattern null ex:p1 ""', function () {
+        var triples, totalCount, hasExactCount;
+        before(function () {
+          return document.searchTriples(null, 'http://example.org/p1',  '""').then(result => {
+            triples = result.triples;
+            totalCount = result.totalCount;
+            hasExactCount = result.hasExactCount;
+          });
+        });
+
+        it('should return an array with matches', function () {
+          triples.should.be.an.Array();
+          triples.should.have.length(0);
+        });
+
+        it('should estimate the total count as 0', function () {
+          totalCount.should.equal(0);
+        });
+
+        it('should be an exact count', function () {
+          hasExactCount.should.equal(true);
+        });
+      });
 
       describe('with pattern null ex:p3 null', function () {
         var triples, totalCount, hasExactCount;


### PR DESCRIPTION
Added a unit test that covers the situation described here: https://github.com/rdfhdt/hdt-cpp/issues/156
Also updated the hdt-cpp version, that includes the fix to that bug

ps. wasn't easy finding a test case where the above happened. I.e., it doesn't happen for _all_ `? <p> <o>`  queries