### PR TITLE
Feature: Fetch distinct predicates given a subject and/or an object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,32 @@ hdtDocument.searchTerms({ prefix: 'http://example.org/', limit: 100, position: '
   });
 ```
 
-### Fetching unique predicates for an object
+### Fetching unique predicates for a subject and/or an object
+
+Find all unique predicates for a given subject argument.
+
+```JavaScript
+hdtDocument.searchTerms({ subject: 'http://example.org/s1' limit: 10, position: 'predicate' })
+  .then(function(terms) {
+    console.log('Found ' + terms.length + ' unique predicates');
+    return hdtDocument.close();
+  });
+```
+
 Find all unique predicates for a given object argument.
 
 ```JavaScript
-hdtDocument.searchTerms({ object: 'http://example.org/o1' limit: 10, position: 'predicate' })
+hdtDocument.searchTerms({ object: 'http://example.org/o1', limit: 10, position: 'predicate' })
+  .then(function(terms) {
+    console.log('Found ' + terms.length + ' unique predicates');
+    return hdtDocument.close();
+  });
+```
+
+Find all unique predicates for given subject and object arguments.
+
+```JavaScript
+hdtDocument.searchTerms({ subject: 'http://example.org/s1', object: 'http://example.org/o1', limit: 10, position: 'predicate' })
   .then(function(terms) {
     console.log('Found ' + terms.length + ' unique predicates');
     return hdtDocument.close();

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -517,10 +517,9 @@ public:
       while (distinctTerms.size() < limit && terms->hasNext()) {
         const char* predicate = reinterpret_cast<char*>(terms->next());
 
-        // Check whether a triple with this predicate and object exists
-        hdt::IteratorTripleString *it;
-        it = (!subject.empty()) ? document->GetHDT()->search(subject.c_str(), predicate, "")
-                                : document->GetHDT()->search("", predicate, object.c_str());
+        // Check whether a triple with this predicate and subject or object exists
+        auto it = (!subject.empty()) ? document->GetHDT()->search(subject.c_str(), predicate, "")
+                                     : document->GetHDT()->search("", predicate, object.c_str());
         if (it->hasNext())
           distinctTerms.push_back(predicate);
         delete it;

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -518,8 +518,7 @@ public:
         const char* predicate = reinterpret_cast<char*>(terms->next());
 
         // Check whether a triple with this predicate and subject or object exists
-        hdt::IteratorTripleString *it = subject.empty() ? document->GetHDT()->search("", predicate, object.c_str())
-                                                        : document->GetHDT()->search(subject.c_str(), predicate, "");
+        hdt::IteratorTripleString *it = document->GetHDT()->search(subject.c_str(), predicate, object.c_str());
         if (it->hasNext())
           distinctTerms.push_back(predicate);
         delete it;

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -518,8 +518,8 @@ public:
         const char* predicate = reinterpret_cast<char*>(terms->next());
 
         // Check whether a triple with this predicate and subject or object exists
-        IteratorUCharString *it = subject.empty() ? document->GetHDT()->search("", predicate, object.c_str())
-                                                  : document->GetHDT()->search(subject.c_str(), predicate, "");
+        hdt::IteratorTripleString *it = subject.empty() ? document->GetHDT()->search("", predicate, object.c_str())
+                                                        : document->GetHDT()->search(subject.c_str(), predicate, "");
         if (it->hasNext())
           distinctTerms.push_back(predicate);
         delete it;

--- a/lib/HdtDocument.cc
+++ b/lib/HdtDocument.cc
@@ -518,8 +518,8 @@ public:
         const char* predicate = reinterpret_cast<char*>(terms->next());
 
         // Check whether a triple with this predicate and subject or object exists
-        auto it = (!subject.empty()) ? document->GetHDT()->search(subject.c_str(), predicate, "")
-                                     : document->GetHDT()->search("", predicate, object.c_str());
+        IteratorUCharString *it = subject.empty() ? document->GetHDT()->search("", predicate, object.c_str())
+                                                  : document->GetHDT()->search(subject.c_str(), predicate, "");
         if (it->hasNext())
           distinctTerms.push_back(predicate);
         delete it;

--- a/lib/HdtDocument.h
+++ b/lib/HdtDocument.h
@@ -36,7 +36,7 @@ class HdtDocument : public node::ObjectWrap {
   static NAN_METHOD(SearchLiterals);
   // HdtDocument#_searchTerms(prefix, limit, position, callback)
   static NAN_METHOD(SearchTerms);
-  // HdtDocument#_fetchDistinctTerms(object, limit, position, callback)
+  // HdtDocument#_fetchDistinctTerms(subject, object, limit, position, callback)
   static NAN_METHOD(FetchDistinctTerms);
   // HdtDocument#_readHeader(callback, self)
   static NAN_METHOD(ReadHeader);

--- a/lib/hdt.d.ts
+++ b/lib/hdt.d.ts
@@ -9,6 +9,7 @@ declare module "hdt" {
     limit?: number;
     position?: "subject" | "predicate" | "object";
     prefix?: string;
+    subject?: string; // mutually exclusive with prefix and prioritized
     object?: string, // mutually exclusive with prefix and prioritized
   }
 

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -54,16 +54,14 @@ HdtDocumentPrototype.searchTerms = function (options) {
       position = options.position,
       posId = POSITIONS[position],
       prefix = options.prefix || '',
-      subject = options.subject,
-      object = options.object;
+      subject = typeof options.subject === 'string' && options.subject.length > 0 ? options.subject : undefined,
+      object = typeof options.object === 'string' && options.object.length > 0 ? options.object : undefined;
+
   if (!(position in POSITIONS))
     return Promise.reject(new Error('Invalid position argument. Expected subject, predicate or object.'));
 
-  if ('subject' in options || 'object' in options) {
-    if (subject === '') return Promise.reject(new Error('Unspecified subject value.'));
-    if (object === '')  return Promise.reject(new Error('Unspecified object value.'));
+  if (subject || object)
     if (posId !== POSITIONS.predicate)  return Promise.reject(new Error('Unsupported position argument. Expected predicate.'));
-  }
 
   if (subject && object) {
     // We can call searchTriples directly
@@ -71,9 +69,10 @@ HdtDocumentPrototype.searchTerms = function (options) {
   }
 
   return new Promise((resolve, reject) => {
-    if (subject || object)
+    if ('subject' in options || 'object' in options) {
+      if (!subject && !object) return resolve([]);
       this._fetchDistinctTerms(subject || '', object || '', limit, posId, (error, results) => error ? reject(error) : resolve(results));
-
+    }
     else {
       // No subject or object values specified, so assuming we're autocompleting a term
       this._searchTerms(prefix, limit, posId, (error, results) => error ? reject(error) : resolve(results));

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -54,20 +54,28 @@ HdtDocumentPrototype.searchTerms = function (options) {
       position = options.position,
       posId = POSITIONS[position],
       prefix = options.prefix || '',
+      subject = options.subject,
       object = options.object;
   if (!(position in POSITIONS))
     return Promise.reject(new Error('Invalid position argument. Expected subject, predicate or object.'));
 
+  if ('subject' in options || 'object' in options) {
+    if (subject === '') return Promise.reject(new Error('Unspecified subject value.'));
+    if (object === '')  return Promise.reject(new Error('Unspecified object value.'));
+    if (posId !== POSITIONS.predicate)  return Promise.reject(new Error('Unsupported position argument. Expected predicate.'));
+  }
+
+  if (subject && object) {
+    // We can call searchTerms directly
+    return this.searchTriples(subject, undefined, object, { limit:limit }).then(result => result.triples.map(statement => statement.predicate));
+  }
+
   return new Promise((resolve, reject) => {
-    if ('object' in options) {
-      if (object === '')
-        return reject(new Error('Unspecified object value.'));
-      if (posId !== POSITIONS.predicate)
-        return reject(new Error('Unsupported position argument. Expected predicate.'));
-      this._fetchDistinctTerms(object, limit, posId, (error, results) => error ? reject(error) : resolve(results));
-    }
+    if (subject || object)
+      this._fetchDistinctTerms(subject || '', object || '', limit, posId, (error, results) => error ? reject(error) : resolve(results));
+
     else {
-      // No object value specified, so assuming we're autocompleting a term
+      // No subject or object values specified, so assuming we're autocompleting a term
       this._searchTerms(prefix, limit, posId, (error, results) => error ? reject(error) : resolve(results));
     }
   });

--- a/lib/hdt.js
+++ b/lib/hdt.js
@@ -66,7 +66,7 @@ HdtDocumentPrototype.searchTerms = function (options) {
   }
 
   if (subject && object) {
-    // We can call searchTerms directly
+    // We can call searchTriples directly
     return this.searchTriples(subject, undefined, object, { limit:limit }).then(result => result.triples.map(statement => statement.predicate));
   }
 

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -186,6 +186,50 @@ describe('hdt', function () {
     });
 
     describe('fetching distinct terms', function () {
+      it('should have correct results for given subject', function () {
+        return document.searchTerms({ subject: 'http://example.org/s1', position: 'predicate' }).then(terms => {
+          terms.should.have.lengthOf(1);
+          terms[0].should.equal('http://example.org/p1');
+        });
+      });
+
+      it('should limit results for given subject', function () {
+        return document.searchTerms({ subject: 'http://example.org/s2', limit: 1, position: 'predicate' }).then(terms => {
+          terms.should.have.lengthOf(1);
+          terms[0].should.equal('http://example.org/p1');
+        });
+      });
+
+      it('should throw on unsupported position (subject-subject)', function () {
+        return document.searchTerms({ subject: 'http://example.org/s1', position: 'subject' }).then(
+          () => Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('Unsupported position argument. Expected predicate.');
+          }
+        );
+      });
+
+      it('should throw on unsupported position (subject-object)', function () {
+        return document.searchTerms({ subject: 'http://example.org/s1', position: 'object' }).then(
+          () => Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('Unsupported position argument. Expected predicate.');
+          }
+        );
+      });
+
+      it('should throw on unspecified subject value', function () {
+        return document.searchTerms({ subject: '', limit: 0, position: 'predicate' }).then(
+          () => Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('Unspecified subject value.');
+          }
+        );
+      });
+
       it('should have correct results for given object', function () {
         return document.searchTerms({ object: 'http://example.org/o001', position: 'predicate' }).then(terms => {
           terms.should.have.lengthOf(2);
@@ -247,10 +291,44 @@ describe('hdt', function () {
         });
       });
 
-      it('should return 0 results on invalid limit', function () {
-        return document.searchTerms({ prefix: 'http://example.org/o001', limit: 'sdf', position: 'predicate' }).then(terms => {
-          terms.should.have.lengthOf(0);
+      it('should return all results on invalid limit', function () {
+        return document.searchTerms({ object: 'http://example.org/o001', limit: 'sdf', position: 'predicate' }).then(terms => {
+          terms.should.have.lengthOf(2);
         });
+      });
+
+      it('should have correct results for given subject and object', function () {
+        return document.searchTerms({ subject: 'http://example.org/s1', object: 'http://example.org/o001', position: 'predicate' }).then(terms => {
+          terms.should.have.lengthOf(1);
+          terms[0].should.equal('http://example.org/p1');
+        });
+      });
+
+      it('should limit results for given subject and object', function () {
+        return document.searchTerms({ subject: 'http://example.org/s2', object: 'http://example.org/o001', limit: 1, position: 'predicate' }).then(terms => {
+          terms.should.have.lengthOf(1);
+          terms[0].should.equal('http://example.org/p1');
+        });
+      });
+
+      it('should throw on unsupported position (subject and object - subject)', function () {
+        return document.searchTerms({ subject: 'http://example.org/s1', object: 'http://example.org/o001', position: 'subject' }).then(
+          () => Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('Unsupported position argument. Expected predicate.');
+          }
+        );
+      });
+
+      it('should throw on unsupported position (subject and object - object)', function () {
+        return document.searchTerms({ subject: 'http://example.org/s1', object: 'http://example.org/o001', position: 'object' }).then(
+          () => Promise.reject(new Error('Expected an error')),
+          error => {
+            error.should.be.an.instanceOf(Error);
+            error.message.should.equal('Unsupported position argument. Expected predicate.');
+          }
+        );
       });
     });
 

--- a/test/hdt-test.js
+++ b/test/hdt-test.js
@@ -220,13 +220,10 @@ describe('hdt', function () {
         );
       });
 
-      it('should throw on unspecified subject value', function () {
-        return document.searchTerms({ subject: '', limit: 0, position: 'predicate' }).then(
-          () => Promise.reject(new Error('Expected an error')),
-          error => {
-            error.should.be.an.instanceOf(Error);
-            error.message.should.equal('Unspecified subject value.');
-          }
+      it('should return 0 results on unspecified subject value', function () {
+        return document.searchTerms({ subject: undefined, position: 'predicate' }).then(terms => {
+          terms.should.have.lengthOf(0);
+        }
         );
       });
 
@@ -275,13 +272,10 @@ describe('hdt', function () {
         );
       });
 
-      it('should throw on unspecified object value', function () {
-        return document.searchTerms({ object: '', limit: 0, position: 'predicate' }).then(
-          () => Promise.reject(new Error('Expected an error')),
-          error => {
-            error.should.be.an.instanceOf(Error);
-            error.message.should.equal('Unspecified object value.');
-          }
+      it('should return 0 results on unspecified object value', function () {
+        return document.searchTerms({ object: '', limit: 0, position: 'predicate' }).then(terms => {
+          terms.should.have.lengthOf(0);
+        }
         );
       });
 


### PR DESCRIPTION
Method `searchTerms` is enhanced in way that it now allows to fetch distinct predicates given a subject and/or an object. The feature is described in issue #33. 
Moreover:
* Added some tests. 
* Updated documentation.

